### PR TITLE
Bottom Nav Bar Updates [1/3]

### DIFF
--- a/app/src/main/java/com/cornellappdev/volume/navigation/MainTabbedNavigation.kt
+++ b/app/src/main/java/com/cornellappdev/volume/navigation/MainTabbedNavigation.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -71,7 +72,7 @@ fun BottomNavigationBar(navController: NavHostController, tabItems: List<Navigat
                         contentDescription = item.title
                     )
                 },
-                label = { Text(text = item.title) },
+                label = { Text(text = item.title, overflow = TextOverflow.Ellipsis, maxLines = 1) },
                 selectedContentColor = VolumeOrange,
                 unselectedContentColor = DarkGray,
                 alwaysShowLabel = true,


### PR DESCRIPTION
## Overview

Elipsize Text in the bottom nav bar.


## Changes Made

- Make text be cut off with ellipses instead overflowing to the next line
-  Set the max number of lines in the bottom nav bar text to 1


## Test Coverage

- manual testing involved checking all accessibility text sizes.



## Next Steps

- Update Bottom nav icons to their most up to date versions
- adjust accessibility options to ensure proper spacing between icons and text (when text size is large)

