### PR TITLE
Search Bug Fixes

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/MagazineComponents.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/MagazineComponents.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -51,6 +52,8 @@ fun CreateMagazineColumn(
                 .width(150.dp)
                 .height(200.dp)
                 .shadow(8.dp)
+                .shimmerEffect(),
+            contentScale = ContentScale.Crop
         )
 
         // Magazine publisher text

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/VolumeGeneralComponents.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/VolumeGeneralComponents.kt
@@ -226,6 +226,15 @@ fun ErrorState(modifier: Modifier = Modifier) {
     )
 }
 
+/**
+ * A composable search bar styled based on Volume design.
+ * @param modifier the generic modifier parameter, it is applied to the text-field.
+ * @param value the value for the search bar
+ * @param onValueChange actions to perform when the value is changed
+ * @param onEnterPressed actions to perform when enter is pressed
+ * @param onClick actions to perform when the search bar is clicked
+ * @param autoFocus whether or not the search bar should automatically be focused when in view
+ */
 @Composable
 fun SearchBar(
     modifier: Modifier = Modifier,

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/SearchScreen.kt
@@ -126,7 +126,7 @@ fun SearchScreen(
                         if (articlesState.articles.isEmpty()) {
                             val recentSearch = search
                             item(span = { GridItemSpan(2) }) {
-                                SearchEmptyState(type = "magazines", recentSearch = recentSearch)
+                                SearchEmptyState(type = "articles", recentSearch = recentSearch)
                             }
                         } else {
                             items(articlesState.articles, span = { GridItemSpan(2) }) { article ->

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/SearchScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.Tab
 import androidx.compose.material.TabRow
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -57,14 +58,26 @@ fun SearchScreen(
     var tabIndex by remember { mutableStateOf(defaultTab) }
     val uiState = searchViewModel.searchUiState
 
+    DisposableEffect(key1 = tabIndex, effect = {
+        if (tabIndex == 0) {
+            searchViewModel.searchArticles(search)
+        } else {
+            searchViewModel.searchMagazines(search)
+        }
+        onDispose { }
+    })
+
     LazyVerticalGrid(columns = GridCells.Fixed(2)) {
         item(span = { GridItemSpan(2) }) {
             SearchBar(
                 value = search,
                 onValueChange = {
                     search = it
-                    searchViewModel.searchArticles(it)
-                    searchViewModel.searchMagazines(it)
+                    if (tabIndex == 0) {
+                        searchViewModel.searchArticles(it)
+                    } else {
+                        searchViewModel.searchMagazines(it)
+                    }
                 },
                 modifier = Modifier.padding(vertical = 12.dp),
                 autoFocus = true,
@@ -165,10 +178,10 @@ fun SearchScreen(
                                 SearchEmptyState(type = "magazines", recentSearch = recentSearch)
                             }
                         } else {
-                            item {
+                            item(span = { GridItemSpan(2) }) {
                                 Spacer(modifier = Modifier.height(10.dp))
                             }
-                            items(magazinesState.magazines, span = { GridItemSpan(2) }) {
+                            items(magazinesState.magazines) {
                                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                                     CreateMagazineColumn(
                                         magazine = it,

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/states/MagazinesRetrievalState.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/states/MagazinesRetrievalState.kt
@@ -7,9 +7,9 @@ import com.cornellappdev.android.volume.data.models.Magazine
  */
 sealed interface MagazinesRetrievalState {
     /**
-     * The articles are successfully retrieved with the given list.
+     * The magazines are successfully retrieved with the given list.
      */
-    data class Success (val magazines: List<Magazine>) : MagazinesRetrievalState
+    data class Success(val magazines: List<Magazine>) : MagazinesRetrievalState
 
     /**
      * There was an error in retrieving the articles.
@@ -17,7 +17,7 @@ sealed interface MagazinesRetrievalState {
     object Error : MagazinesRetrievalState
 
     /**
-     * The articles are in the process of being retrieved.
+     * The magazines are in the process of being retrieved.
      */
     object Loading : MagazinesRetrievalState
 }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/SearchViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/SearchViewModel.kt
@@ -26,8 +26,10 @@ class SearchViewModel @Inject constructor(
 
     data class SearchUiState(
 
-        val searchedMagazinesState: MagazinesRetrievalState = MagazinesRetrievalState.Error,
-        val searchedArticlesState: ArticlesRetrievalState = ArticlesRetrievalState.Loading,
+        val searchedMagazinesState: MagazinesRetrievalState = MagazinesRetrievalState.Success(
+            emptyList()
+        ),
+        val searchedArticlesState: ArticlesRetrievalState = ArticlesRetrievalState.Success(emptyList()),
     )
 
     var searchUiState by mutableStateOf(SearchUiState())

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/SearchViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/SearchViewModel.kt
@@ -25,7 +25,8 @@ class SearchViewModel @Inject constructor(
 ) : ViewModel() {
 
     data class SearchUiState(
-        val searchedMagazinesState: MagazinesRetrievalState = MagazinesRetrievalState.Loading,
+
+        val searchedMagazinesState: MagazinesRetrievalState = MagazinesRetrievalState.Error,
         val searchedArticlesState: ArticlesRetrievalState = ArticlesRetrievalState.Loading,
     )
 
@@ -47,6 +48,7 @@ class SearchViewModel @Inject constructor(
         searchUiState = searchUiState.copy(
             searchedMagazinesState = MagazinesRetrievalState.Loading
         )
+
         // Cancel any previous jobs so we don't unnecessarily load those search results.
         magazineJob.cancel()
         magazineJob = viewModelScope.launch {


### PR DESCRIPTION

## Overview

I fixed two small bugs regarding the search screen


## Changes Made

- Instead of searching for both articles and magazines at once, it only searches for it depending on which tab you are on. This fixed a bug with magazines getting reset to the loading state.
- Fixed the unsearched states for magazine and articles tabs, so it shows that you have not made a search yet instead of showing a loading screen.
