### PR TITLE
Use testing data to make final fixes for cboard update

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/volume/data/models/Flyer.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/models/Flyer.kt
@@ -16,9 +16,9 @@ data class Flyer(
     val location: String,
 ) : Comparable<Flyer> {
     val endDateTime: LocalDateTime =
-        LocalDateTime.parse(endDate, DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+        LocalDateTime.parse(endDate, DateTimeFormatter.ISO_DATE_TIME)
     val startDateTime: LocalDateTime =
-        LocalDateTime.parse(startDate, DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))
+        LocalDateTime.parse(startDate, DateTimeFormatter.ISO_DATE_TIME)
 
     override fun compareTo(other: Flyer): Int {
         return endDateTime.compareTo(other.endDateTime)

--- a/app/src/main/java/com/cornellappdev/android/volume/data/repositories/FlyerRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/repositories/FlyerRepository.kt
@@ -22,7 +22,8 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
         networkApi.fetchFlyersBeforeDate(date).dataAssertNoErrors.mapDataToFlyers()
 
     suspend fun fetchOrganizationsByCategorySlug(slug: String): List<Organization> =
-        networkApi.fetchOrganizationsByCategory(category = slug).dataAssertNoErrors.mapOrganizationCategoryDataToOrganizations()
+        networkApi.fetchOrganizationsByCategory(category = slug).dataAssertNoErrors
+            .mapOrganizationCategoryDataToOrganizations()
 
     suspend fun fetchFlyersByOrganizationSlugs(ids: List<String>): List<Flyer> =
         networkApi.fetchFlyersByOrganizationSlugs(ids).dataAssertNoErrors.mapDataToFlyers()

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
@@ -309,7 +310,8 @@ fun OrganizationAndIconsRow(
             fontWeight = FontWeight.Medium,
             fontSize = 12.sp,
             maxLines = 1,
-            overflow = TextOverflow.Ellipsis
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.widthIn(0.dp, 150.dp)
         )
         Spacer(modifier = Modifier.weight(1F))
         // Bookmark icon
@@ -420,9 +422,16 @@ private fun getAverageColor(immutableBitmap: Bitmap): Int {
 private fun formatDateString(startDateTime: LocalDateTime, endDateTime: LocalDateTime): String =
     try {
         val formatter = DateTimeFormatter.ofPattern("h:mm a")
+        val dayOfWeek = startDateTime.dayOfWeek.toString().substring(0, 3)
+            .lowercase()
+            .replaceFirstChar { c -> c.uppercase() }
+        val month = startDateTime.month.toString()
+            .lowercase()
+            .replaceFirstChar { c -> c.uppercase() }
+        val dayOfMonth = startDateTime.dayOfMonth
         val startTime = formatter.format(startDateTime)
         val endTime = formatter.format(endDateTime)
-        "$startTime - $endTime"
+        "$dayOfWeek, $month $dayOfMonth   $startTime - $endTime"
     } catch (ignored: Exception) {
         startDateTime.toString()
     }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/FlyersViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/FlyersViewModel.kt
@@ -1,6 +1,5 @@
 package com.cornellappdev.android.volume.ui.viewmodels
 
-import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -101,7 +100,6 @@ class FlyersViewModel @Inject constructor(
                 )
                 queryUpcomingFlyers(categorySlug = "all")
             } catch (e: Exception) {
-                Log.e(TAG, "queryWeeklyFlyers: error", e)
                 weeklyFlyers = listOf()
                 flyersUiState = flyersUiState.copy(
                     weeklyFlyersState = FlyersRetrievalState.Error
@@ -124,7 +122,6 @@ class FlyersViewModel @Inject constructor(
                     flyersUiState.copy(upcomingFlyersState = FlyersRetrievalState.Loading)
                 if (categorySlug.lowercase() == "all") {
                     val initialFlyers = flyerRepository.fetchFlyersAfterDate(getToday())
-                    Log.d(TAG, "queryUpcomingFlyers: $initialFlyers")
                     flyersUiState = flyersUiState.copy(
                         upcomingFlyersState = FlyersRetrievalState.Success(
                             initialFlyers
@@ -156,7 +153,6 @@ class FlyersViewModel @Inject constructor(
                     queryPastFlyers()
                 }
             } catch (e: Exception) {
-                Log.e(TAG, "queryUpcomingFlyers: error", e)
                 flyersUiState = flyersUiState.copy(
                     upcomingFlyersState = FlyersRetrievalState.Error
                 )


### PR DESCRIPTION
## Overview

Made some fixes to Flyers networking using new test data to ensure proper functionality. 


## Changes Made

- Fixed date parsing for flyers to use ISO DateTime
- Fixed loading of upcoming Flyers to never show past flyers
- Initialize `lateinit` variables even if network requests failed to prevent any app crashes.

## Screenshots & Videos

<details>

  <summary>Weekly Flyers</summary>


![Screenshot_1692547700](https://github.com/cuappdev/volume-compose-android/assets/58796478/6a6a7997-a439-4204-8b8f-03e6e2eb64ae)
  

</details>

<details>

  <summary>Upcoming and Past Flyers</summary>


![Screenshot_1692547707](https://github.com/cuappdev/volume-compose-android/assets/58796478/5e0b70a9-e484-45af-be08-04be4666922f)
64ae)
  

</details>