### PR TITLE
Add search for Flyers, center search bar on Reads screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
         applicationId "com.cornellappdev.android.volume"
         minSdk 27
         targetSdk 33
-        versionCode 7
-        versionName "1.2.2"
+        versionCode 9
+        versionName "1.2.4"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "FEEDBACK_FORM", secretsProperties['FEEDBACK_FORM'])

--- a/app/src/main/graphql/com/cornellappdev/android/volume/queries.graphql
+++ b/app/src/main/graphql/com/cornellappdev/android/volume/queries.graphql
@@ -997,6 +997,35 @@ mutation IncrementShoutouts($id: String!, $uuid: String!){
     }
 }
 
+query SearchFlyers($limit: Float, $query: String!){
+    searchFlyers(limit: $limit, query: $query){
+        id
+        endDate
+        flyerURL
+        imageURL
+        isTrending
+        location
+        nsfw
+        organizations{
+            backgroundImageURL
+            bio
+            categorySlug
+            name
+            profileImageURL
+            slug
+            shoutouts
+            websiteURL
+            numFlyers
+            clicks
+        }
+        organizationSlugs
+        startDate
+        timesClicked
+        title
+        trendiness
+    }
+}
+
 mutation IncrementTimesClicked($id: String!){
     incrementTimesClicked(id: $id){
         id

--- a/app/src/main/java/com/cornellappdev/android/volume/data/NetworkingApi.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/NetworkingApi.kt
@@ -31,6 +31,7 @@ import com.cornellappdev.android.volume.OrganizationsByCategoryQuery
 import com.cornellappdev.android.volume.PublicationBySlugQuery
 import com.cornellappdev.android.volume.ReadArticleMutation
 import com.cornellappdev.android.volume.SearchArticlesQuery
+import com.cornellappdev.android.volume.SearchFlyersQuery
 import com.cornellappdev.android.volume.SearchMagazinesQuery
 import com.cornellappdev.android.volume.ShuffledArticlesByPublicationSlugsQuery
 import com.cornellappdev.android.volume.TrendingArticlesQuery
@@ -137,6 +138,9 @@ class NetworkApi @Inject constructor(private val apolloClient: ApolloClient) {
 
     suspend fun fetchFlyersBeforeDate(date: String): ApolloResponse<FlyersBeforeDateQuery.Data> =
         apolloClient.query(FlyersBeforeDateQuery(before = date)).execute()
+
+    suspend fun fetchSearchedFlyers(query: String): ApolloResponse<SearchFlyersQuery.Data> =
+        apolloClient.query(SearchFlyersQuery(query = query)).execute()
 
     suspend fun fetchFlyersByOrganizationSlugs(slugs: List<String>): ApolloResponse<FlyersByOrganizationSlugsQuery.Data> =
         apolloClient.query(FlyersByOrganizationSlugsQuery(slugs = slugs))

--- a/app/src/main/java/com/cornellappdev/android/volume/data/repositories/FlyerRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/repositories/FlyerRepository.kt
@@ -5,6 +5,7 @@ import com.cornellappdev.android.volume.FlyersBeforeDateQuery
 import com.cornellappdev.android.volume.FlyersByIDsQuery
 import com.cornellappdev.android.volume.FlyersByOrganizationSlugsQuery
 import com.cornellappdev.android.volume.OrganizationsByCategoryQuery
+import com.cornellappdev.android.volume.SearchFlyersQuery
 import com.cornellappdev.android.volume.TrendingFlyersQuery
 import com.cornellappdev.android.volume.data.NetworkApi
 import com.cornellappdev.android.volume.data.models.Flyer
@@ -38,7 +39,24 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
     suspend fun fetchTrendingFlyers(): List<Flyer> =
         networkApi.fetchTrendingFlyers().dataAssertNoErrors.mapDataToFlyers()
 
+    suspend fun fetchSearchedFlyers(query: String): List<Flyer> =
+        networkApi.fetchSearchedFlyers(query).dataAssertNoErrors.mapDataToFlyers()
+
     // These functions map the apollo query types to types of the models that are in place.
+    private fun SearchFlyersQuery.Data.mapDataToFlyers(): List<Flyer> =
+        this.searchFlyers.map { flyer ->
+            Flyer(
+                id = flyer.id,
+                title = flyer.title,
+                organizations = flyer.organizations.mapSearchDataToOrganizations(),
+                flyerURL = flyer.flyerURL,
+                startDate = flyer.startDate as String,
+                endDate = flyer.endDate as String,
+                imageURL = flyer.imageURL,
+                location = flyer.location,
+            )
+        }
+
 
     private fun FlyersByIDsQuery.Data.mapDataToFlyers(): List<Flyer> =
         this.getFlyersByIDs.map { flyer ->
@@ -166,5 +184,16 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
                 categorySlug = organization.categorySlug,
             )
         }
+
+    private fun List<SearchFlyersQuery.Organization>.mapSearchDataToOrganizations(): List<Organization> =
+        this.map { organization ->
+            Organization(
+                name = organization.name,
+                slug = organization.slug,
+                categorySlug = organization.categorySlug
+            )
+        }
 }
+
+
 

--- a/app/src/main/java/com/cornellappdev/android/volume/navigation/MainTabbedNavigation.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/navigation/MainTabbedNavigation.kt
@@ -308,7 +308,9 @@ private fun MainScreenNavigationConfigurations(
         }
 
         composable(Routes.FLYERS.route) {
-            FlyersScreen()
+            FlyersScreen(onSearchClick = {
+                navController.navigate("${Routes.SEARCH.route}/$it")
+            })
         }
         composable(
             Routes.BOOKMARKS.route,

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
@@ -173,7 +173,7 @@ fun SmallFlyer(
 
     var modifier = Modifier
         .fillMaxWidth()
-        .padding(bottom = 16.dp, end = 16.dp)
+        .padding(bottom = 16.dp)
     if (inUpcoming) {
         modifier = Modifier
             .width(352.dp)

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/VolumeLoadingComponents.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/VolumeLoadingComponents.kt
@@ -77,8 +77,8 @@ fun BigShimmeringFlyer(imgWidth: Int, imgHeight: Int) {
 }
 
 @Composable
-fun ShimmeringFlyer() {
-    Row (modifier = Modifier.padding(end = 84.dp)) {
+fun ShimmeringFlyer(inUpcoming: Boolean = true) {
+    Row (modifier = Modifier.padding(end = if (inUpcoming) 84.dp else 0.dp)) {
         ShimmeringBox(width = 92, height = 92)
         Spacer(modifier = Modifier.width(8.dp))
         Column {

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/FlyersScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/FlyersScreen.kt
@@ -43,6 +43,7 @@ import com.cornellappdev.android.volume.ui.components.general.BigFlyer
 import com.cornellappdev.android.volume.ui.components.general.BigShimmeringFlyer
 import com.cornellappdev.android.volume.ui.components.general.ErrorState
 import com.cornellappdev.android.volume.ui.components.general.NothingToShowMessage
+import com.cornellappdev.android.volume.ui.components.general.SearchBar
 import com.cornellappdev.android.volume.ui.components.general.ShimmeringFlyer
 import com.cornellappdev.android.volume.ui.components.general.SmallFlyer
 import com.cornellappdev.android.volume.ui.components.general.VolumeHeaderText
@@ -56,6 +57,7 @@ import com.cornellappdev.android.volume.util.FlyerConstants
 @Composable
 fun FlyersScreen(
     flyersViewModel: FlyersViewModel = hiltViewModel(),
+    onSearchClick: (Int) -> Unit,
 ) {
     var selectedIndex by remember { mutableStateOf(0) }
     val tags = FlyerConstants.CATEGORY_SLUGS.split(",")
@@ -76,6 +78,7 @@ fun FlyersScreen(
         "If you want to see your organization's events on Volume, email us at volumeappdev@gmail.com"
 
     LazyColumn(modifier = Modifier.padding(start = 16.dp)) {
+        // Page title
         item {
             Row {
                 Text(
@@ -88,11 +91,21 @@ fun FlyersScreen(
                 VolumePeriod(modifier = Modifier.padding(top = 39.dp, start = 7.dp))
             }
         }
+        // Search bar
+        item {
+            Box(modifier = Modifier.padding(end = 16.dp, top = 16.dp)) {
+                SearchBar(
+                    value = "",
+                    onValueChange = {},
+                    onClick = { onSearchClick(2) },
+                )
+            }
+        }
         // Today header
         item {
             Spacer(
                 modifier = Modifier
-                    .height(32.dp)
+                    .height(16.dp)
                     .fillMaxWidth()
             )
             VolumeHeaderText(text = "Today", underline = R.drawable.ic_today_underline)
@@ -337,7 +350,9 @@ fun FlyersScreen(
                     }
                 } else {
                     items(flyers) {
-                        SmallFlyer(inUpcoming = false, it)
+                        Box(modifier = Modifier.padding(end = 16.dp)) {
+                            SmallFlyer(inUpcoming = false, it)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/ReadsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/ReadsScreen.kt
@@ -110,11 +110,13 @@ fun ReadsScreen(
                                     })
                             Spacer(modifier = Modifier.weight(2F))
                         }
-                        SearchBar(value = "",
-                            onValueChange = {},
-                            modifier = Modifier
-                                .padding(end = 16.dp, top = 16.dp),
-                            onClick = { onSearchClick(tabIndex) })
+                        Box(modifier = Modifier.padding(start = 16.dp)) {
+                            SearchBar(value = "",
+                                onValueChange = {},
+                                modifier = Modifier
+                                    .padding(end = 16.dp, top = 16.dp),
+                                onClick = { onSearchClick(tabIndex) })
+
 
                         when (tabIndex) {
                             0 -> {

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/ReadsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/ReadsScreen.kt
@@ -116,6 +116,7 @@ fun ReadsScreen(
                                 modifier = Modifier
                                     .padding(end = 16.dp, top = 16.dp),
                                 onClick = { onSearchClick(tabIndex) })
+                        }
 
 
                         when (tabIndex) {
@@ -135,5 +136,4 @@ fun ReadsScreen(
             }
         )
     }
-
 }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/SearchScreen.kt
@@ -5,6 +5,7 @@ import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -35,8 +36,11 @@ import com.cornellappdev.android.volume.ui.components.general.ErrorState
 import com.cornellappdev.android.volume.ui.components.general.NothingToShowMessage
 import com.cornellappdev.android.volume.ui.components.general.SearchBar
 import com.cornellappdev.android.volume.ui.components.general.ShimmeringArticle
+import com.cornellappdev.android.volume.ui.components.general.ShimmeringFlyer
 import com.cornellappdev.android.volume.ui.components.general.ShimmeringMagazine
+import com.cornellappdev.android.volume.ui.components.general.SmallFlyer
 import com.cornellappdev.android.volume.ui.states.ArticlesRetrievalState
+import com.cornellappdev.android.volume.ui.states.FlyersRetrievalState
 import com.cornellappdev.android.volume.ui.states.MagazinesRetrievalState
 import com.cornellappdev.android.volume.ui.theme.VolumeOffWhite
 import com.cornellappdev.android.volume.ui.theme.VolumeOrange
@@ -54,29 +58,32 @@ fun SearchScreen(
     defaultTab: Int = 0,
 ) {
     var search by remember { mutableStateOf("") }
-    val tabs = listOf("Articles", "Magazines")
+    val tabs = listOf("Articles", "Magazines", "Flyers")
     var tabIndex by remember { mutableStateOf(defaultTab) }
     val uiState = searchViewModel.searchUiState
 
     DisposableEffect(key1 = tabIndex, effect = {
-        if (tabIndex == 0) {
-            searchViewModel.searchArticles(search)
-        } else {
-            searchViewModel.searchMagazines(search)
+        when (tabIndex) {
+            0 -> searchViewModel.searchArticles(search)
+            1 -> searchViewModel.searchMagazines(search)
+            2 -> searchViewModel.searchFlyers(search)
         }
         onDispose { }
     })
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(2),
 
-    LazyVerticalGrid(columns = GridCells.Fixed(2)) {
+
+        ) {
         item(span = { GridItemSpan(2) }) {
             SearchBar(
                 value = search,
                 onValueChange = {
                     search = it
-                    if (tabIndex == 0) {
-                        searchViewModel.searchArticles(it)
-                    } else {
-                        searchViewModel.searchMagazines(it)
+                    when (tabIndex) {
+                        0 -> searchViewModel.searchArticles(it)
+                        1 -> searchViewModel.searchMagazines(it)
+                        2 -> searchViewModel.searchFlyers(it)
                     }
                 },
                 modifier = Modifier.padding(vertical = 12.dp),
@@ -109,6 +116,7 @@ fun SearchScreen(
         }
         when (tabIndex) {
             0 -> {
+                // Show articles
                 when (val articlesState = uiState.searchedArticlesState) {
                     ArticlesRetrievalState.Loading -> {
                         items(4, span = { GridItemSpan(2) }) {
@@ -129,7 +137,9 @@ fun SearchScreen(
                                 SearchEmptyState(type = "articles", recentSearch = recentSearch)
                             }
                         } else {
-                            items(articlesState.articles, span = { GridItemSpan(2) }) { article ->
+                            items(
+                                articlesState.articles,
+                                span = { GridItemSpan(2) }) { article ->
                                 Box(
                                     modifier = Modifier.padding(
                                         vertical = 10.dp,
@@ -175,7 +185,10 @@ fun SearchScreen(
                         if (magazinesState.magazines.isEmpty()) {
                             val recentSearch = search
                             item(span = { GridItemSpan(2) }) {
-                                SearchEmptyState(type = "magazines", recentSearch = recentSearch)
+                                SearchEmptyState(
+                                    type = "magazines",
+                                    recentSearch = recentSearch
+                                )
                             }
                         } else {
                             item(span = { GridItemSpan(2) }) {
@@ -193,9 +206,64 @@ fun SearchScreen(
                     }
                 }
             }
+
+            2 -> {
+                // show Flyers
+                when (val searchedFlyersState = uiState.searchedFlyersState) {
+                    FlyersRetrievalState.Loading -> {
+                        items(10, span = { GridItemSpan(2) }) {
+                            if (it % 2 == 1) {
+                                Column(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalAlignment = Alignment.CenterHorizontally,
+                                ) {
+                                    ShimmeringFlyer(inUpcoming = false)
+
+                                }
+                            } else {
+                                Spacer(modifier = Modifier.height(16.dp))
+                            }
+                        }
+                    }
+
+                    FlyersRetrievalState.Error -> {
+                        item(span = { GridItemSpan(2) }) {
+                            ErrorState()
+                        }
+                    }
+
+                    is FlyersRetrievalState.Success -> {
+                        val flyers = searchedFlyersState.flyers
+                        val recentSearch = search
+                        if (flyers.isEmpty()) {
+                            item(span = { GridItemSpan(2) }) {
+                                SearchEmptyState(type = "flyers", recentSearch = recentSearch)
+                            }
+                        } else {
+                            item(span = { GridItemSpan(2) }) {
+                                Spacer(modifier = Modifier.height(16.dp))
+                            }
+                            items(
+                                flyers,
+                                span = { GridItemSpan(2) }) {
+                                Column(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalAlignment = Alignment.CenterHorizontally
+                                ) {
+                                    Box(modifier = Modifier.padding(horizontal = 16.dp)) {
+                                        SmallFlyer(inUpcoming = false, it)
+                                    }
+                                }
+                                Spacer(modifier = Modifier.height(16.dp))
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }
+
 
 @Composable
 fun SearchEmptyState(type: String, recentSearch: String) {


### PR DESCRIPTION
## Overview

Added search functionality for Flyers and fixed some previous formatting issues.


## Changes Made

- Flyers now appear centered when they should be
- Search bar is now centered on Reads screen
- Search bar was added to Flyers screen, and takes you to Flyers section of the search screen
- Networking and display of searched Flyers has been implemented


## Test Coverage

Tested the features on the dev server and everything worked as expeced.


## Screenshots & Videos

[readsdemo.webm](https://github.com/cuappdev/volume-compose-android/assets/58796478/663418d5-1050-40b3-a051-34d38135ba2f)

