### PR TITLE
Fix times formatted with time zone

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/volume/data/models/Flyer.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/models/Flyer.kt
@@ -2,6 +2,8 @@ package com.cornellappdev.android.volume.data.models
 
 import com.squareup.moshi.JsonClass
 import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 @JsonClass(generateAdapter = true)
@@ -16,9 +18,11 @@ data class Flyer(
     val location: String,
 ) : Comparable<Flyer> {
     val endDateTime: LocalDateTime =
-        LocalDateTime.parse(endDate, DateTimeFormatter.ISO_DATE_TIME)
+        ZonedDateTime.parse(endDate, DateTimeFormatter.ISO_DATE_TIME)
+            .withZoneSameInstant(ZoneId.of(ZonedDateTime.now().zone.id)).toLocalDateTime()
     val startDateTime: LocalDateTime =
-        LocalDateTime.parse(startDate, DateTimeFormatter.ISO_DATE_TIME)
+        ZonedDateTime.parse(startDate, DateTimeFormatter.ISO_DATE_TIME)
+            .withZoneSameInstant(ZoneId.of(ZonedDateTime.now().zone.id)).toLocalDateTime()
 
     override fun compareTo(other: Flyer): Int {
         return endDateTime.compareTo(other.endDateTime)

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
@@ -423,17 +423,12 @@ private fun getAverageColor(immutableBitmap: Bitmap): Int {
  */
 private fun formatDateString(startDateTime: LocalDateTime, endDateTime: LocalDateTime): String =
     try {
-        val formatter = DateTimeFormatter.ofPattern("h:mm a")
-        val dayOfWeek = startDateTime.dayOfWeek.toString().substring(0, 3)
-            .lowercase()
-            .replaceFirstChar { c -> c.uppercase() }
-        val month = startDateTime.month.toString()
-            .lowercase()
-            .replaceFirstChar { c -> c.uppercase() }
-        val dayOfMonth = startDateTime.dayOfMonth
-        val startTime = formatter.format(startDateTime)
-        val endTime = formatter.format(endDateTime)
-        "$dayOfWeek, $month $dayOfMonth   $startTime - $endTime"
+        val startFormatter = DateTimeFormatter.ofPattern("EEE, MMM d   h:mm a")
+        val endFormatter = DateTimeFormatter.ofPattern("h:mm a")
+
+        val start = startFormatter.format(startDateTime)
+        val end = endFormatter.format(endDateTime)
+        "$start - $end"
     } catch (ignored: Exception) {
         startDateTime.toString()
     }


### PR DESCRIPTION
## Overview

Micro PR to fix an issue where timestamps were being parsed without considering the time zone. Also made date formatting code more concise.


## Screenshots & Videos


Correct times being displayed for each Flyer:
 <img src="https://github.com/cuappdev/volume-compose-android/assets/58796478/e54a200c-3c77-4b3d-9d64-2d66a927b000" width=400/>  -->
  

</details>
