### PR TITLE
New Upcoming Flyers Display

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
         applicationId "com.cornellappdev.android.volume"
         minSdk 27
         targetSdk 33
-        versionCode 9
-        versionName "1.2.4"
+        versionCode 10
+        versionName "1.2.5"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "FEEDBACK_FORM", secretsProperties['FEEDBACK_FORM'])

--- a/app/src/main/java/com/cornellappdev/android/volume/data/models/Flyer.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/models/Flyer.kt
@@ -2,6 +2,8 @@ package com.cornellappdev.android.volume.data.models
 
 import com.squareup.moshi.JsonClass
 import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 @JsonClass(generateAdapter = true)
@@ -16,9 +18,11 @@ data class Flyer(
     val location: String,
 ) : Comparable<Flyer> {
     val endDateTime: LocalDateTime =
-        LocalDateTime.parse(endDate, DateTimeFormatter.ISO_DATE_TIME)
+        ZonedDateTime.parse(endDate, DateTimeFormatter.ISO_DATE_TIME)
+            .withZoneSameInstant(ZoneId.of(ZonedDateTime.now().zone.id)).toLocalDateTime()
     val startDateTime: LocalDateTime =
-        LocalDateTime.parse(startDate, DateTimeFormatter.ISO_DATE_TIME)
+        ZonedDateTime.parse(startDate, DateTimeFormatter.ISO_DATE_TIME)
+            .withZoneSameInstant(ZoneId.of(ZonedDateTime.now().zone.id)).toLocalDateTime()
 
     override fun compareTo(other: Flyer): Int {
         return endDateTime.compareTo(other.endDateTime)

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
@@ -423,17 +423,12 @@ private fun getAverageColor(immutableBitmap: Bitmap): Int {
  */
 private fun formatDateString(startDateTime: LocalDateTime, endDateTime: LocalDateTime): String =
     try {
-        val formatter = DateTimeFormatter.ofPattern("h:mm a")
-        val dayOfWeek = startDateTime.dayOfWeek.toString().substring(0, 3)
-            .lowercase()
-            .replaceFirstChar { c -> c.uppercase() }
-        val month = startDateTime.month.toString()
-            .lowercase()
-            .replaceFirstChar { c -> c.uppercase() }
-        val dayOfMonth = startDateTime.dayOfMonth
-        val startTime = formatter.format(startDateTime)
-        val endTime = formatter.format(endDateTime)
-        "$dayOfWeek, $month $dayOfMonth   $startTime - $endTime"
+        val startFormatter = DateTimeFormatter.ofPattern("EEE, MMM d   h:mm a")
+        val endFormatter = DateTimeFormatter.ofPattern("h:mm a")
+
+        val start = startFormatter.format(startDateTime)
+        val end = endFormatter.format(endDateTime)
+        "$start - $end"
     } catch (ignored: Exception) {
         startDateTime.toString()
     }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
@@ -153,10 +153,10 @@ fun BigFlyer(imgSize: Dp, flyer: Flyer, flyersViewModel: FlyersViewModel = hiltV
 
 @Composable
 fun SmallFlyer(
-    inUpcoming: Boolean,
+    isExtraSmall: Boolean,
     flyer: Flyer,
     flyersViewModel: FlyersViewModel = hiltViewModel(),
-    showTag: Boolean = !inUpcoming,
+    showTag: Boolean = !isExtraSmall,
 ) {
     val imageURL = flyer.imageURL
     val context = LocalContext.current
@@ -170,13 +170,15 @@ fun SmallFlyer(
     // Gets the average image color for background
     LaunchedEffect(key1 = flyer.imageURL) {
         imageBitmap = getBitmap(imageURL, context)
-        averageColor = getAverageColor(imageBitmap!!).toComposeColor()
+        imageBitmap?.let {
+            averageColor = getAverageColor(it).toComposeColor()
+        }
     }
 
     var modifier = Modifier
         .fillMaxWidth()
         .padding(bottom = 16.dp)
-    if (inUpcoming) {
+    if (isExtraSmall) {
         modifier = Modifier
             .width(352.dp)
             .padding(bottom = 16.dp, end = 16.dp)
@@ -196,7 +198,7 @@ fun SmallFlyer(
             AsyncImage(
                 model = flyer.imageURL,
                 contentDescription = null,
-                modifier = if (inUpcoming) Modifier
+                modifier = if (isExtraSmall) Modifier
                     .background(color = averageColor)
                     .size(123.dp) else Modifier
                     .size(width = 130.dp, height = 130.dp)
@@ -220,6 +222,8 @@ fun SmallFlyer(
                 fontFamily = notoserif,
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Medium,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
             )
             Spacer(
                 modifier = Modifier

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/BookmarkScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/BookmarkScreen.kt
@@ -283,10 +283,18 @@ fun BookmarkedFlyersView(
             is FlyersRetrievalState.Success -> {
                 if (upcomingState.flyers.isEmpty()) {
                     item {
-                        NothingToShowMessage(
-                            title = "No bookmarked flyers",
-                            message = "You can bookmark them from the trending page or the flyers page"
-                        )
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .requiredHeight(312.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.Center,
+                        ) {
+                            NothingToShowMessage(
+                                title = "No bookmarked upcoming flyers",
+                                message = "You can bookmark them from the trending page or the flyers page"
+                            )
+                        }
                     }
                 } else {
                     item {
@@ -305,7 +313,7 @@ fun BookmarkedFlyersView(
 
         // Past and dropdown menu
         item {
-            Spacer(modifier = Modifier.height(40.dp))
+            Spacer(modifier = Modifier.height(32.dp))
 
             Row {
                 VolumeHeaderText(text = "Past Flyers", underline = R.drawable.ic_underline_upcoming)

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/BookmarkScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/BookmarkScreen.kt
@@ -295,7 +295,7 @@ fun BookmarkedFlyersView(
                             modifier = Modifier.height(308.dp)
                         ) {
                             items(upcomingState.flyers) {
-                                SmallFlyer(inUpcoming = true, flyer = it)
+                                SmallFlyer(isExtraSmall = true, flyer = it)
                             }
                         }
                     }
@@ -430,7 +430,7 @@ fun BookmarkedFlyersView(
                         )
                     }
                     items(pastState.flyers) {
-                        SmallFlyer(inUpcoming = false, flyer = it, showTag = false)
+                        SmallFlyer(isExtraSmall = false, flyer = it, showTag = false)
                         Spacer(
                             modifier = Modifier
                                 .height(16.dp)

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/FlyersScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/FlyersScreen.kt
@@ -1,6 +1,5 @@
 package com.cornellappdev.android.volume.ui.screens
 
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -14,9 +13,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
-import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
@@ -260,10 +256,6 @@ fun FlyersScreen(
                                 DropdownMenuItem(onClick = {
                                     selectedIndex = index
                                     expanded = false
-                                    Log.d(
-                                        "TAG",
-                                        "FlyersScreen: Querying for tag ${tags[selectedIndex]} "
-                                    )
                                     flyersViewModel.queryUpcomingFlyers(tags[selectedIndex])
                                 }) {
                                     Text(
@@ -280,44 +272,40 @@ fun FlyersScreen(
             }
             Spacer(modifier = Modifier.height(8.dp))
         }
-        // Small flyer display
-        item {
-            when (val upcomingFlyerState = uiState.upcomingFlyersState) {
-                FlyersRetrievalState.Loading -> {
-                    LazyHorizontalGrid(
-                        rows = GridCells.Fixed(3),
-                        modifier = Modifier.height(308.dp)
-                    ) {
-                        items(9) {
-                            ShimmeringFlyer()
-                        }
-                    }
+        // Upcoming flyer display
+        when (val upcomingFlyerState = uiState.upcomingFlyersState) {
+            FlyersRetrievalState.Loading -> {
+                items(5) {
+                    ShimmeringFlyer()
+                    Spacer(modifier = Modifier.height(16.dp))
                 }
+            }
 
-                FlyersRetrievalState.Error -> {
+            FlyersRetrievalState.Error -> {
+                item {
                     ErrorState()
                 }
+            }
 
-                is FlyersRetrievalState.Success -> {
-                    val flyers = upcomingFlyerState.flyers
-                    if (flyers.isEmpty()) {
+            is FlyersRetrievalState.Success -> {
+                val flyers = upcomingFlyerState.flyers
+                if (flyers.isEmpty()) {
+                    item {
                         NothingToShowMessage(
-                            title = "No upcoming flyers for this category",
-                            message = NO_FLYERS_MESSAGE
+                            title = "No upcoming flyers",
+                            message = "If you want to see your organization’s events on Volume, email us at volumeappdev@gmail.com"
                         )
-                    } else {
-                        LazyHorizontalGrid(
-                            rows = GridCells.Fixed(3),
-                            modifier = Modifier.height(308.dp)
-                        ) {
-                            items(flyers) {
-                                SmallFlyer(inUpcoming = true, it)
-                            }
+                    }
+                } else {
+                    items(flyers) {
+                        Box(modifier = Modifier.padding(end = 16.dp)) {
+                            SmallFlyer(isExtraSmall = false, it)
                         }
                     }
                 }
             }
         }
+
 
         item {
             Spacer(modifier = Modifier.height(40.dp))
@@ -351,7 +339,7 @@ fun FlyersScreen(
                 } else {
                     items(flyers) {
                         Box(modifier = Modifier.padding(end = 16.dp)) {
-                            SmallFlyer(inUpcoming = false, it)
+                            SmallFlyer(isExtraSmall = false, it)
                         }
                     }
                 }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/SearchScreen.kt
@@ -251,7 +251,7 @@ fun SearchScreen(
                                     horizontalAlignment = Alignment.CenterHorizontally
                                 ) {
                                     Box(modifier = Modifier.padding(horizontal = 16.dp)) {
-                                        SmallFlyer(inUpcoming = false, it)
+                                        SmallFlyer(isExtraSmall = false, it)
                                     }
                                 }
                                 Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/SearchScreen.kt
@@ -86,7 +86,7 @@ fun SearchScreen(
                         2 -> searchViewModel.searchFlyers(it)
                     }
                 },
-                modifier = Modifier.padding(vertical = 12.dp),
+                modifier = Modifier.padding(vertical = 12.dp, horizontal = 16.dp),
                 autoFocus = true,
             )
         }


### PR DESCRIPTION
## Overview

Changes the upcoming flyers display to be consistent with that of past flyers. Some miscellaneous bug fixes and improvements are also in this PR.


## Changes Made

- Fixed times for Flyers being incorrectly parsed due to timezone issue
- Greatly improved concision of date time formatting code for Flyers
- Changed upcoming view to match past flyers view on Flyers page
- Fixed padding issue in search screen
- Fixed padding issue in bookmarks screen


## Screenshots & Videos

<!-- If you are making any changes to UI, you should use this section. -->

<details>

  <summary>New Upcoming Flyers display, date parsing fixed</summary>
<img src="https://github.com/cuappdev/volume-compose-android/assets/58796478/30b91e35-a424-4272-bbd3-3e1586267468" width=400 />

  

</details>

<details>

  <summary>Fixed padding on search screen</summary>
<img src="https://github.com/cuappdev/volume-compose-android/assets/58796478/9ca0577e-3977-43c6-ab57-c1d5166098d3" width=400 />
  

</details>

<details>

  <summary>Fixed padding for upcoming flyers empty state on bookmarks screen</summary>
<img src="https://github.com/cuappdev/volume-compose-android/assets/58796478/2e552221-00eb-4ebb-adcd-307d2826979a" width=400 />
  

</details>