### PR TITLE
Zach/content types fix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
         applicationId "com.cornellappdev.android.volume"
         minSdk 27
         targetSdk 33
-        versionCode 12
-        versionName "1.2.7"
+        versionCode 13
+        versionName "1.2.8"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "FEEDBACK_FORM", secretsProperties['FEEDBACK_FORM'])

--- a/app/src/main/graphql/com/cornellappdev/android/volume/queries.graphql
+++ b/app/src/main/graphql/com/cornellappdev/android/volume/queries.graphql
@@ -11,7 +11,6 @@ query AllArticles ($limit: Float) {
             rssURL
             slug
             shoutouts
-            contentTypes
             websiteURL
             numArticles
             socials {
@@ -55,7 +54,6 @@ query AllPublications {
         shoutouts
         websiteURL
         numArticles
-        contentTypes
         socials {
             social
             url:URL
@@ -83,7 +81,6 @@ query PublicationBySlug($slug: String!) {
         slug
         shoutouts
         websiteURL
-        contentTypes
         numArticles
         socials {
             social
@@ -114,7 +111,6 @@ query TrendingArticles ($limit: Float) {
             rssURL
             slug
             shoutouts
-            contentTypes
             numArticles
             websiteURL
             socials {
@@ -154,7 +150,6 @@ query ArticlesByPublicationSlug($slug: String!) {
             rssURL
             slug
             shoutouts
-            contentTypes
             websiteURL
             numArticles
             socials {
@@ -226,7 +221,6 @@ query ShuffledArticlesByPublicationSlugs($timeRange: Float, $offset: Float, $lim
             slug
             shoutouts
             websiteURL
-            contentTypes
             numArticles
             socials{
                 social
@@ -262,7 +256,6 @@ query MagazinesBySemester($offset: Float, $limit: Float, $semester: String!){
             slug
             shoutouts
             websiteURL
-            contentTypes
             numArticles
             socials{
                 social
@@ -299,7 +292,6 @@ query MagazineById($id: String!){
             slug
             shoutouts
             websiteURL
-            contentTypes
             numArticles
             socials{
                 social
@@ -334,7 +326,6 @@ query MagazinesByIDs($ids: [String!]!){
             slug
             shoutouts
             websiteURL
-            contentTypes
             numArticles
             socials{
                 social
@@ -370,7 +361,6 @@ query FeaturedMagazines($limit: Float){
             slug
             shoutouts
             websiteURL
-            contentTypes
             numArticles
             socials{
                 social
@@ -406,7 +396,6 @@ query MagazinesByPublicationSlug($offset: Float, $limit: Float, $slug: String!){
             slug
             shoutouts
             websiteURL
-            contentTypes
             numArticles
             socials{
                 social
@@ -443,7 +432,6 @@ query AllMagazines ($limit: Float) {
             slug
             shoutouts
             websiteURL
-            contentTypes
             numArticles
             socials{
                 social
@@ -478,7 +466,6 @@ query SearchMagazines($limit: Float, $query: String!){
             slug
             shoutouts
             websiteURL
-            contentTypes
             numArticles
             socials {
                 social
@@ -504,7 +491,6 @@ query ArticlesByIDs($ids:[String!]!) {
             rssURL
             slug
             shoutouts
-            contentTypes
             websiteURL
             numArticles
             socials {
@@ -542,7 +528,6 @@ query ArticleByID($id: String!) {
             rssURL
             slug
             shoutouts
-            contentTypes
             websiteURL
             numArticles
             socials {
@@ -582,7 +567,6 @@ query ArticlesByPublicationSlugs($slugs: [String!]!) {
             rssURL
             slug
             shoutouts
-            contentTypes
             numArticles
             websiteURL
             socials {
@@ -623,7 +607,6 @@ query ArticlesAfterDate($since: String!) {
             rssURL
             slug
             shoutouts
-            contentTypes
             numArticles
             websiteURL
             socials {
@@ -961,7 +944,6 @@ mutation IncrementMagazineShoutouts($id: String!, $uuid: String!){
             slug
             shoutouts
             websiteURL
-            contentTypes
             numArticles
         }
         publicationSlug
@@ -992,7 +974,6 @@ mutation IncrementShoutouts($id: String!, $uuid: String!){
             slug
             shoutouts
             websiteURL
-            contentTypes
             numArticles
         }
         publicationSlug

--- a/app/src/main/graphql/com/cornellappdev/android/volume/schema.graphqls
+++ b/app/src/main/graphql/com/cornellappdev/android/volume/schema.graphqls
@@ -154,7 +154,6 @@ type Publication {
     slug: String!
     shoutouts: Float!
     websiteURL: String!
-    contentTypes: [String!]!
 
     """The most recent <Article> of a <Publication>"""
     mostRecentArticle: Article

--- a/app/src/main/java/com/cornellappdev/android/volume/data/models/Publication.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/models/Publication.kt
@@ -12,7 +12,6 @@ package com.cornellappdev.android.volume.data.models
  * @property slug
  * @property shoutouts
  * @property websiteURL
- * @property contentTypes
  * @property mostRecentArticle
  * @property socials
  */
@@ -26,12 +25,7 @@ data class Publication(
     val slug: String,
     val shoutouts: Double,
     val websiteURL: String,
-    val contentTypes: List<ContentType>,
     val numArticles: Double,
     val mostRecentArticle: Article? = null,
     val socials: List<Social>,
 )
-
-enum class ContentType {
-    MAGAZINES, ARTICLES
-}

--- a/app/src/main/java/com/cornellappdev/android/volume/data/repositories/ArticleRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/repositories/ArticleRepository.kt
@@ -11,7 +11,6 @@ import com.cornellappdev.android.volume.ShuffledArticlesByPublicationSlugsQuery
 import com.cornellappdev.android.volume.TrendingArticlesQuery
 import com.cornellappdev.android.volume.data.NetworkApi
 import com.cornellappdev.android.volume.data.models.Article
-import com.cornellappdev.android.volume.data.models.ContentType
 import com.cornellappdev.android.volume.data.models.Publication
 import com.cornellappdev.android.volume.data.models.Social
 import javax.inject.Inject
@@ -70,13 +69,6 @@ class ArticleRepository @Inject constructor(private val networkApi: NetworkApi) 
                     rssURL = publication.rssURL,
                     slug = publication.slug,
                     shoutouts = publication.shoutouts,
-                    /*
-                    * FIXME content types is an empty list, since the backend gives an internal
-                    * server error when searching articles and looking for content types.
-                    * Once this is fixed we should be searching for articles and
-                    * include their content types.
-                    */
-                    contentTypes = listOf(),
                     websiteURL = publication.websiteURL,
                     numArticles = publication.numArticles,
                     socials = publication.socials
@@ -107,9 +99,6 @@ class ArticleRepository @Inject constructor(private val networkApi: NetworkApi) 
                     rssURL = publication.rssURL,
                     slug = publication.slug,
                     shoutouts = publication.shoutouts,
-                    contentTypes = publication.contentTypes.map {
-                        ContentType.valueOf(it.uppercase())
-                    },
                     websiteURL = publication.websiteURL,
                     numArticles = publication.numArticles,
                     socials = publication.socials
@@ -140,9 +129,6 @@ class ArticleRepository @Inject constructor(private val networkApi: NetworkApi) 
                     rssURL = publication.rssURL,
                     slug = publication.slug,
                     shoutouts = publication.shoutouts,
-                    contentTypes = publication.contentTypes.map {
-                        ContentType.valueOf(it.uppercase())
-                    },
                     numArticles = publication.numArticles,
                     websiteURL = publication.websiteURL,
                     socials = publication.socials
@@ -172,9 +158,6 @@ class ArticleRepository @Inject constructor(private val networkApi: NetworkApi) 
                     rssURL = publication.rssURL,
                     slug = publication.slug,
                     shoutouts = publication.shoutouts,
-                    contentTypes = publication.contentTypes.map {
-                        ContentType.valueOf(it.uppercase())
-                    },
                     numArticles = publication.numArticles,
                     websiteURL = publication.websiteURL,
                     socials = publication.socials
@@ -204,9 +187,6 @@ class ArticleRepository @Inject constructor(private val networkApi: NetworkApi) 
                     rssURL = publication.rssURL,
                     slug = publication.slug,
                     shoutouts = publication.shoutouts,
-                    contentTypes = publication.contentTypes.map {
-                        ContentType.valueOf(it.uppercase())
-                    },
                     numArticles = publication.numArticles,
                     websiteURL = publication.websiteURL,
                     socials = publication.socials
@@ -236,9 +216,6 @@ class ArticleRepository @Inject constructor(private val networkApi: NetworkApi) 
                     rssURL = publication.rssURL,
                     slug = publication.slug,
                     shoutouts = publication.shoutouts,
-                    contentTypes = publication.contentTypes.map {
-                        ContentType.valueOf(it.uppercase())
-                    },
                     numArticles = publication.numArticles,
                     websiteURL = publication.websiteURL,
                     socials = publication.socials
@@ -268,9 +245,6 @@ class ArticleRepository @Inject constructor(private val networkApi: NetworkApi) 
                     rssURL = publication.rssURL,
                     slug = publication.slug,
                     shoutouts = publication.shoutouts,
-                    contentTypes = publication.contentTypes.map {
-                        ContentType.valueOf(it.uppercase())
-                    },
                     numArticles = publication.numArticles,
                     websiteURL = publication.websiteURL,
                     socials = publication.socials
@@ -300,9 +274,6 @@ class ArticleRepository @Inject constructor(private val networkApi: NetworkApi) 
                     rssURL = publication.rssURL,
                     slug = publication.slug,
                     shoutouts = publication.shoutouts,
-                    contentTypes = publication.contentTypes.map {
-                        ContentType.valueOf(it.uppercase())
-                    },
                     websiteURL = publication.websiteURL,
                     numArticles = publication.numArticles,
                     socials = publication.socials

--- a/app/src/main/java/com/cornellappdev/android/volume/data/repositories/MagazineRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/repositories/MagazineRepository.kt
@@ -9,7 +9,6 @@ import com.cornellappdev.android.volume.MagazinesByPublicationSlugQuery
 import com.cornellappdev.android.volume.MagazinesBySemesterQuery
 import com.cornellappdev.android.volume.SearchMagazinesQuery
 import com.cornellappdev.android.volume.data.NetworkApi
-import com.cornellappdev.android.volume.data.models.ContentType
 import com.cornellappdev.android.volume.data.models.Magazine
 import com.cornellappdev.android.volume.data.models.Publication
 import com.cornellappdev.android.volume.data.models.Social
@@ -74,9 +73,6 @@ class MagazineRepository @Inject constructor(private val networkApi: NetworkApi)
                     rssURL = publication.rssURL,
                     slug = publication.slug,
                     shoutouts = publication.shoutouts,
-                    contentTypes = publication.contentTypes.map {
-                        ContentType.valueOf(it.uppercase())
-                    },
                     websiteURL = publication.websiteURL,
                     numArticles = publication.numArticles,
                     socials = publication.socials.map {
@@ -109,9 +105,6 @@ class MagazineRepository @Inject constructor(private val networkApi: NetworkApi)
                     rssURL = publication.rssURL,
                     slug = publication.slug,
                     shoutouts = publication.shoutouts,
-                    contentTypes = publication.contentTypes.map {
-                        ContentType.valueOf(it.uppercase())
-                    },
                     websiteURL = publication.websiteURL,
                     numArticles = publication.numArticles,
                     socials = publication.socials.map {
@@ -142,9 +135,6 @@ class MagazineRepository @Inject constructor(private val networkApi: NetworkApi)
                     rssURL = publication.rssURL,
                     slug = publication.slug,
                     shoutouts = publication.shoutouts,
-                    contentTypes = publication.contentTypes.map {
-                        ContentType.valueOf(it.uppercase())
-                    },
                     websiteURL = publication.websiteURL,
                     numArticles = publication.numArticles,
                     socials = publication.socials.map {
@@ -175,13 +165,10 @@ class MagazineRepository @Inject constructor(private val networkApi: NetworkApi)
                     rssURL = publication.rssURL,
                     slug = publication.slug,
                     shoutouts = publication.shoutouts,
-                    contentTypes = publication.contentTypes.map {
-                        ContentType.valueOf(it.uppercase())
-                    },
                     websiteURL = publication.websiteURL,
                     numArticles = publication.numArticles,
-                    socials = publication.socials.map {
-                        Social(it.social, it.url)
+                    socials = publication.socials.map { s ->
+                        Social(s.social, s.url)
                     }
                 ),
                 shoutouts = it.shoutouts
@@ -208,13 +195,10 @@ class MagazineRepository @Inject constructor(private val networkApi: NetworkApi)
                     rssURL = publication.rssURL,
                     slug = publication.slug,
                     shoutouts = publication.shoutouts,
-                    contentTypes = publication.contentTypes.map {
-                        ContentType.valueOf(it.uppercase())
-                    },
                     websiteURL = publication.websiteURL,
                     numArticles = publication.numArticles,
-                    socials = publication.socials.map {
-                        Social(it.social, it.url)
+                    socials = publication.socials.map { s ->
+                        Social(s.social, s.url)
                     }
                 ),
                 shoutouts = it.shoutouts
@@ -242,9 +226,6 @@ class MagazineRepository @Inject constructor(private val networkApi: NetworkApi)
                 rssURL = publication.rssURL,
                 slug = publication.slug,
                 shoutouts = publication.shoutouts,
-                contentTypes = publication.contentTypes.map {
-                    ContentType.valueOf(it.uppercase())
-                },
                 websiteURL = publication.websiteURL,
                 numArticles = publication.numArticles,
                 socials = publication.socials.map {
@@ -275,9 +256,6 @@ class MagazineRepository @Inject constructor(private val networkApi: NetworkApi)
                     rssURL = publication.rssURL,
                     slug = publication.slug,
                     shoutouts = publication.shoutouts,
-                    contentTypes = publication.contentTypes.map {
-                        ContentType.valueOf(it.uppercase())
-                    },
                     websiteURL = publication.websiteURL,
                     numArticles = publication.numArticles,
                     socials = publication.socials.map {

--- a/app/src/main/java/com/cornellappdev/android/volume/data/repositories/PublicationRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/repositories/PublicationRepository.kt
@@ -5,7 +5,6 @@ import com.cornellappdev.android.volume.AllPublicationsQuery
 import com.cornellappdev.android.volume.PublicationBySlugQuery
 import com.cornellappdev.android.volume.data.NetworkApi
 import com.cornellappdev.android.volume.data.models.Article
-import com.cornellappdev.android.volume.data.models.ContentType
 import com.cornellappdev.android.volume.data.models.Publication
 import com.cornellappdev.android.volume.data.models.Social
 import javax.inject.Inject
@@ -18,6 +17,7 @@ import javax.inject.Singleton
  * @see Article
  */
 private const val TAG = "PublicationRepository"
+
 @Singleton
 class PublicationRepository @Inject constructor(private val networkApi: NetworkApi) {
     class PublicationNotFound : Exception()
@@ -54,9 +54,6 @@ class PublicationRepository @Inject constructor(private val networkApi: NetworkA
                 slug = publicationData.slug,
                 shoutouts = publicationData.shoutouts,
                 numArticles = publicationData.numArticles,
-                contentTypes = publicationData.contentTypes.map {
-                    ContentType.valueOf(it.uppercase())
-                },
                 websiteURL = publicationData.websiteURL,
                 mostRecentArticle = publicationData.mostRecentArticle?.nsfw?.let { isNSFW ->
                     Article(
@@ -74,9 +71,6 @@ class PublicationRepository @Inject constructor(private val networkApi: NetworkA
                             slug = publicationData.slug,
                             shoutouts = publicationData.shoutouts,
                             numArticles = publicationData.numArticles,
-                            contentTypes = publicationData.contentTypes.map {
-                                ContentType.valueOf(it.uppercase())
-                            },
                             websiteURL = publicationData.websiteURL,
                             socials = publicationData.socials
                                 .map { Social(it.social, it.url) }),
@@ -101,9 +95,6 @@ class PublicationRepository @Inject constructor(private val networkApi: NetworkA
                 rssURL = publicationData.rssURL,
                 slug = publicationData.slug,
                 shoutouts = publicationData.shoutouts,
-                contentTypes = publicationData.contentTypes.map {
-                    ContentType.valueOf(it.uppercase())
-                },
                 numArticles = publicationData.numArticles,
                 websiteURL = publicationData.websiteURL,
                 mostRecentArticle = publicationData.mostRecentArticle?.nsfw?.let { isNSFW ->
@@ -122,9 +113,6 @@ class PublicationRepository @Inject constructor(private val networkApi: NetworkA
                             rssURL = publicationData.rssURL,
                             slug = publicationData.slug,
                             shoutouts = publicationData.shoutouts,
-                            contentTypes = publicationData.contentTypes.map {
-                                ContentType.valueOf(it.uppercase())
-                            },
                             websiteURL = publicationData.websiteURL,
                             numArticles = publicationData.numArticles,
                             socials = publicationData.socials

--- a/app/src/main/java/com/cornellappdev/android/volume/navigation/MainTabbedNavigation.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/navigation/MainTabbedNavigation.kt
@@ -412,7 +412,7 @@ private fun MainScreenNavigationConfigurations(
                 organizationId = orgId ?: "",
                 onFlyerUploadSuccess = { navController.navigate(Routes.FLYER_SUCCESS.route) })
         }
-        composable(route = "${Routes.FLYER_SUCCESS.route}", enterTransition = {
+        composable(route = Routes.FLYER_SUCCESS.route, enterTransition = {
             fadeIn(
                 initialAlpha = 0f,
                 animationSpec = tween(durationMillis = 1000)

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/onboarding/SecondPage.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/onboarding/SecondPage.kt
@@ -52,7 +52,6 @@ import com.cornellappdev.android.volume.R
 import com.cornellappdev.android.volume.analytics.EventType
 import com.cornellappdev.android.volume.analytics.NavigationSource
 import com.cornellappdev.android.volume.analytics.VolumeEvent
-import com.cornellappdev.android.volume.data.models.ContentType
 import com.cornellappdev.android.volume.ui.components.general.CreatePublicationRow
 import com.cornellappdev.android.volume.ui.components.general.ErrorState
 import com.cornellappdev.android.volume.ui.states.PublicationsRetrievalState
@@ -155,33 +154,31 @@ fun SecondPage(
                             ) { publication ->
                                 // Clicking on row IN onboarding should not lead to IndividualPublicationScreen. They are not
                                 // an official user yet so they shouldn't be interacting with the articles.
-                                if (!publication.contentTypes.contains(ContentType.MAGAZINES)) {
-                                    CreatePublicationRow(publication = publication) { publicationFromCallback, isFollowing ->
-                                        if (isFollowing) {
-                                            onboardingViewModel.addPublicationToFollowed(
-                                                publicationFromCallback.slug
-                                            )
-                                            VolumeEvent.logEvent(
-                                                EventType.PUBLICATION,
-                                                VolumeEvent.FOLLOW_PUBLICATION,
-                                                NavigationSource.ONBOARDING,
-                                                publicationFromCallback.slug
-                                            )
-                                        } else {
-                                            onboardingViewModel.removePublicationFromFollowed(
-                                                publicationFromCallback.slug
-                                            )
-                                            VolumeEvent.logEvent(
-                                                EventType.PUBLICATION,
-                                                VolumeEvent.UNFOLLOW_PUBLICATION,
-                                                NavigationSource.ONBOARDING,
-                                                publicationFromCallback.slug
-                                            )
-                                        }
-
-                                        proceedEnabled =
-                                            onboardingViewModel.setOfPubsFollowed.isNotEmpty()
+                                CreatePublicationRow(publication = publication) { publicationFromCallback, isFollowing ->
+                                    if (isFollowing) {
+                                        onboardingViewModel.addPublicationToFollowed(
+                                            publicationFromCallback.slug
+                                        )
+                                        VolumeEvent.logEvent(
+                                            EventType.PUBLICATION,
+                                            VolumeEvent.FOLLOW_PUBLICATION,
+                                            NavigationSource.ONBOARDING,
+                                            publicationFromCallback.slug
+                                        )
+                                    } else {
+                                        onboardingViewModel.removePublicationFromFollowed(
+                                            publicationFromCallback.slug
+                                        )
+                                        VolumeEvent.logEvent(
+                                            EventType.PUBLICATION,
+                                            VolumeEvent.UNFOLLOW_PUBLICATION,
+                                            NavigationSource.ONBOARDING,
+                                            publicationFromCallback.slug
+                                        )
                                     }
+
+                                    proceedEnabled =
+                                        onboardingViewModel.setOfPubsFollowed.isNotEmpty()
                                 }
                             }
                         }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/PublicationsMenu.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/PublicationsMenu.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.cornellappdev.android.volume.R
-import com.cornellappdev.android.volume.data.models.ContentType
 import com.cornellappdev.android.volume.data.models.Publication
 import com.cornellappdev.android.volume.ui.components.general.CreatePublicationColumn
 import com.cornellappdev.android.volume.ui.components.general.CreatePublicationRow
@@ -99,28 +98,26 @@ fun PublicationsMenu(
 
             is PublicationsRetrievalState.Success -> {
                 itemsIndexed(morePublicationsState.publications) { index, publication ->
-                    if (!publication.contentTypes.contains(ContentType.MAGAZINES)) {
-                        Box(
-                            Modifier.padding(
-                                end = 12.dp,
-                                start = 12.dp,
-                                // Handles the padding between items
-                                top = if (index != 0) 24.dp else 0.dp
-                            )
-                        ) {
-                            CreatePublicationRow(
-                                publication = publication,
-                                onPublicationClick
-                            ) { publicationFromCallback, isFollowing ->
-                                if (isFollowing) {
-                                    publicationsViewModel.followPublication(
-                                        publicationFromCallback.slug
-                                    )
-                                } else {
-                                    publicationsViewModel.unfollowPublication(
-                                        publicationFromCallback.slug
-                                    )
-                                }
+                    Box(
+                        Modifier.padding(
+                            end = 12.dp,
+                            start = 12.dp,
+                            // Handles the padding between items
+                            top = if (index != 0) 24.dp else 0.dp
+                        )
+                    ) {
+                        CreatePublicationRow(
+                            publication = publication,
+                            onPublicationClick
+                        ) { publicationFromCallback, isFollowing ->
+                            if (isFollowing) {
+                                publicationsViewModel.followPublication(
+                                    publicationFromCallback.slug
+                                )
+                            } else {
+                                publicationsViewModel.unfollowPublication(
+                                    publicationFromCallback.slug
+                                )
                             }
                         }
                     }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/TrendingViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/TrendingViewModel.kt
@@ -1,5 +1,6 @@
 package com.cornellappdev.android.volume.ui.viewmodels
 
+import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -50,6 +51,7 @@ class TrendingViewModel @Inject constructor(
             )
             getFeaturedArticles()
         } catch (e: java.lang.Exception) {
+            Log.d(TAG, "getMainFeaturedArticle: FAILED: ${e.message}")
             trendingUiState = trendingUiState.copy(
                 mainFeaturedArticleRetrievalState = ArticleRetrievalState.Error
             )

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/TrendingViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/TrendingViewModel.kt
@@ -1,6 +1,5 @@
 package com.cornellappdev.android.volume.ui.viewmodels
 
-import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -51,7 +50,6 @@ class TrendingViewModel @Inject constructor(
             )
             getFeaturedArticles()
         } catch (e: java.lang.Exception) {
-            Log.d(TAG, "getMainFeaturedArticle: FAILED: ${e.message}")
             trendingUiState = trendingUiState.copy(
                 mainFeaturedArticleRetrievalState = ArticleRetrievalState.Error
             )


### PR DESCRIPTION
## Overview

Remove content types for publications for Android. There is an issue with the backend that has caused Articles to go down because of publication content types. iOS does not use this field so this change fixes Android while also making it more consistent with iOS.


## Changes Made

- Removed `contentTypes` field from publication model
- Updated all code that used publication model to adapt to this change


## Test Coverage

- Tested loading the app, articles load successfully.
- Also tested onboarding flow with publications to make sure that it still works.

## Screenshots
<img src="https://github.com/cuappdev/volume-compose-android/assets/58796478/3c6cdc38-2557-44d6-9b04-aedaeea663d7" width=300 />


