### PR TITLE
Organizations Home and Upload Refactor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,7 +98,6 @@ dependencies {
     implementation 'androidx.compose.runtime:runtime-rxjava2:1.2.1'
     implementation 'com.apollographql.apollo3:apollo-runtime:3.1.0'
     implementation 'com.squareup.okhttp3:okhttp'
-    implementation("com.squareup.moshi:moshi-kotlin:1.14.0")
     implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,6 @@ secretsProperties.load(new FileInputStream(secretsPropertiesFile))
 
 android {
     compileSdk 33
-
     defaultConfig {
         applicationId "com.cornellappdev.android.volume"
         minSdk 27

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,8 @@ android {
         applicationId "com.cornellappdev.android.volume"
         minSdk 27
         targetSdk 33
-        versionCode 13
-        versionName "1.2.8"
+        versionCode 14
+        versionName "1.2.9"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "FEEDBACK_FORM", secretsProperties['FEEDBACK_FORM'])

--- a/app/src/main/graphql/com/cornellappdev/android/volume/queries.graphql
+++ b/app/src/main/graphql/com/cornellappdev/android/volume/queries.graphql
@@ -822,6 +822,34 @@ query FlyersByOrganizationId($offset: Float, $limit: Float, $organizationId: Str
     }
 }
 
+query FlyersByOrganizationSlug($offset: Float, $limit: Float, $slug: String!){
+    getFlyersByOrganizationSlug(offset: $offset, limit: $limit, slug: $slug){
+        id
+        categorySlug
+        endDate
+        flyerURL
+        imageURL
+        location
+        organization{
+            id
+            backgroundImageURL
+            bio
+            categorySlug
+            name
+            profileImageURL
+            slug
+            shoutouts
+            websiteURL
+            clicks
+        }
+        organizationSlug
+        startDate
+        timesClicked
+        title
+        trendiness
+    }
+}
+
 query OrganizationsByCategory($categorySlug: String!){
     getOrganizationsByCategory(categorySlug: $categorySlug){
         id
@@ -838,6 +866,21 @@ query OrganizationsByCategory($categorySlug: String!){
 }
 query OrganizationsById($id: String!){
     getOrganizationByID(id: $id){
+        id
+        backgroundImageURL
+        bio
+        categorySlug
+        name
+        profileImageURL
+        slug
+        shoutouts
+        websiteURL
+        clicks
+    }
+}
+
+query OrganizationBySlug($slug: String!) {
+    getOrganizationBySlug(slug: $slug) {
         id
         backgroundImageURL
         bio

--- a/app/src/main/graphql/com/cornellappdev/android/volume/queries.graphql
+++ b/app/src/main/graphql/com/cornellappdev/android/volume/queries.graphql
@@ -1153,3 +1153,31 @@ mutation createFlyer($title: String!, $startDate: String!, $organizationID: Stri
     }
 }
 
+mutation DeleteFlyer($id: String!){
+    deleteFlyer(id: $id){
+        id
+        categorySlug
+        endDate
+        flyerURL
+        imageURL
+        location
+        organization{
+            id
+            backgroundImageURL
+            bio
+            categorySlug
+            name
+            profileImageURL
+            slug
+            shoutouts
+            websiteURL
+            clicks
+        }
+        organizationSlug
+        startDate
+        timesClicked
+        title
+        trendiness
+    }
+}
+

--- a/app/src/main/graphql/com/cornellappdev/android/volume/queries.graphql
+++ b/app/src/main/graphql/com/cornellappdev/android/volume/queries.graphql
@@ -794,6 +794,34 @@ query FlyersByCategorySlug($offset: Float, $limit: Float, $categorySlug: String!
     }
 }
 
+query FlyersByOrganizationId($offset: Float, $limit: Float, $organizationId: String!){
+    getFlyersByOrganizationID(offset: $offset, limit: $limit, organizationID: $organizationId){
+        id
+        categorySlug
+        endDate
+        flyerURL
+        imageURL
+        location
+        organization{
+            id
+            backgroundImageURL
+            bio
+            categorySlug
+            name
+            profileImageURL
+            slug
+            shoutouts
+            websiteURL
+            clicks
+        }
+        organizationSlug
+        startDate
+        timesClicked
+        title
+        trendiness
+    }
+}
+
 query OrganizationsByCategory($categorySlug: String!){
     getOrganizationsByCategory(categorySlug: $categorySlug){
         id

--- a/app/src/main/java/com/cornellappdev/android/volume/data/NetworkingApi.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/NetworkingApi.kt
@@ -16,6 +16,7 @@ import com.cornellappdev.android.volume.CheckAccessCodeQuery
 import com.cornellappdev.android.volume.CreateFlyerMutation
 import com.cornellappdev.android.volume.CreateUserMutation
 import com.cornellappdev.android.volume.FeaturedMagazinesQuery
+import com.cornellappdev.android.volume.FlyerByIDQuery
 import com.cornellappdev.android.volume.FlyersAfterDateQuery
 import com.cornellappdev.android.volume.FlyersBeforeDateQuery
 import com.cornellappdev.android.volume.FlyersByCategorySlugQuery
@@ -158,6 +159,9 @@ class NetworkApi @Inject constructor(private val apolloClient: ApolloClient) {
 
     suspend fun fetchOrganizationById(id: String): ApolloResponse<OrganizationsByIdQuery.Data> =
         apolloClient.query(OrganizationsByIdQuery(id = id)).execute()
+
+    suspend fun fetchFlyerById(id: String): ApolloResponse<FlyerByIDQuery.Data> =
+        apolloClient.query(FlyerByIDQuery(id = id)).execute()
 
     suspend fun incrementShoutout(
         id: String,

--- a/app/src/main/java/com/cornellappdev/android/volume/data/NetworkingApi.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/NetworkingApi.kt
@@ -2,7 +2,6 @@ package com.cornellappdev.android.volume.data
 
 import android.content.Context
 import android.net.Uri
-import android.util.Log
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Optional
@@ -206,9 +205,6 @@ class NetworkApi @Inject constructor(private val apolloClient: ApolloClient) {
                 .build()
 
         client.newCall(request).execute().use { response ->
-            if (!response.isSuccessful) {
-                Log.d("UPLOAD", "mutateFlyer: ${response.code}, ${response.body.toString()}")
-            }
             return response.isSuccessful
         }
     }

--- a/app/src/main/java/com/cornellappdev/android/volume/data/NetworkingApi.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/NetworkingApi.kt
@@ -20,6 +20,7 @@ import com.cornellappdev.android.volume.FlyersAfterDateQuery
 import com.cornellappdev.android.volume.FlyersBeforeDateQuery
 import com.cornellappdev.android.volume.FlyersByCategorySlugQuery
 import com.cornellappdev.android.volume.FlyersByIDsQuery
+import com.cornellappdev.android.volume.FlyersByOrganizationIdQuery
 import com.cornellappdev.android.volume.FollowPublicationMutation
 import com.cornellappdev.android.volume.GetUserQuery
 import com.cornellappdev.android.volume.IncrementMagazineShoutoutsMutation
@@ -29,7 +30,6 @@ import com.cornellappdev.android.volume.MagazineByIdQuery
 import com.cornellappdev.android.volume.MagazinesByIDsQuery
 import com.cornellappdev.android.volume.MagazinesByPublicationSlugQuery
 import com.cornellappdev.android.volume.MagazinesBySemesterQuery
-import com.cornellappdev.android.volume.OrganizationsByCategoryQuery
 import com.cornellappdev.android.volume.OrganizationsByIdQuery
 import com.cornellappdev.android.volume.PublicationBySlugQuery
 import com.cornellappdev.android.volume.ReadArticleMutation
@@ -149,11 +149,12 @@ class NetworkApi @Inject constructor(private val apolloClient: ApolloClient) {
         apolloClient.query(FlyersByCategorySlugQuery(categorySlug = slug))
             .execute()
 
-    suspend fun fetchOrganizationsByCategory(category: String): ApolloResponse<OrganizationsByCategoryQuery.Data> =
-        apolloClient.query(OrganizationsByCategoryQuery(categorySlug = category)).execute()
+    suspend fun fetchFlyersByOrganizationId(id: String): ApolloResponse<FlyersByOrganizationIdQuery.Data> =
+        apolloClient.query(FlyersByOrganizationIdQuery(organizationId = id)).execute()
 
     suspend fun fetchOrganizationById(id: String): ApolloResponse<OrganizationsByIdQuery.Data> =
         apolloClient.query(OrganizationsByIdQuery(id = id)).execute()
+
 
     suspend fun incrementShoutout(
         id: String,

--- a/app/src/main/java/com/cornellappdev/android/volume/data/NetworkingApi.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/NetworkingApi.kt
@@ -20,7 +20,7 @@ import com.cornellappdev.android.volume.FlyersAfterDateQuery
 import com.cornellappdev.android.volume.FlyersBeforeDateQuery
 import com.cornellappdev.android.volume.FlyersByCategorySlugQuery
 import com.cornellappdev.android.volume.FlyersByIDsQuery
-import com.cornellappdev.android.volume.FlyersByOrganizationIdQuery
+import com.cornellappdev.android.volume.FlyersByOrganizationSlugQuery
 import com.cornellappdev.android.volume.FollowPublicationMutation
 import com.cornellappdev.android.volume.GetUserQuery
 import com.cornellappdev.android.volume.IncrementMagazineShoutoutsMutation
@@ -30,6 +30,7 @@ import com.cornellappdev.android.volume.MagazineByIdQuery
 import com.cornellappdev.android.volume.MagazinesByIDsQuery
 import com.cornellappdev.android.volume.MagazinesByPublicationSlugQuery
 import com.cornellappdev.android.volume.MagazinesBySemesterQuery
+import com.cornellappdev.android.volume.OrganizationBySlugQuery
 import com.cornellappdev.android.volume.OrganizationsByIdQuery
 import com.cornellappdev.android.volume.PublicationBySlugQuery
 import com.cornellappdev.android.volume.ReadArticleMutation
@@ -149,12 +150,14 @@ class NetworkApi @Inject constructor(private val apolloClient: ApolloClient) {
         apolloClient.query(FlyersByCategorySlugQuery(categorySlug = slug))
             .execute()
 
-    suspend fun fetchFlyersByOrganizationId(id: String): ApolloResponse<FlyersByOrganizationIdQuery.Data> =
-        apolloClient.query(FlyersByOrganizationIdQuery(organizationId = id)).execute()
+    suspend fun fetchFlyersByOrganizationSlug(slug: String): ApolloResponse<FlyersByOrganizationSlugQuery.Data> =
+        apolloClient.query(FlyersByOrganizationSlugQuery(slug = slug)).execute()
+
+    suspend fun fetchOrganizationBySlug(slug: String): ApolloResponse<OrganizationBySlugQuery.Data> =
+        apolloClient.query(OrganizationBySlugQuery(slug = slug)).execute()
 
     suspend fun fetchOrganizationById(id: String): ApolloResponse<OrganizationsByIdQuery.Data> =
         apolloClient.query(OrganizationsByIdQuery(id = id)).execute()
-
 
     suspend fun incrementShoutout(
         id: String,

--- a/app/src/main/java/com/cornellappdev/android/volume/data/models/Flyer.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/models/Flyer.kt
@@ -1,12 +1,10 @@
 package com.cornellappdev.android.volume.data.models
 
-import com.squareup.moshi.JsonClass
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
-@JsonClass(generateAdapter = true)
 data class Flyer(
     val id: String,
     val title: String,

--- a/app/src/main/java/com/cornellappdev/android/volume/data/models/Organization.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/models/Organization.kt
@@ -7,6 +7,7 @@ data class Organization(
     val websiteURL: String,
     val backgroundImageURL: String? = null,
     val bio: String? = null,
+    val slug: String,
 )
 
 val organizationTypes = listOf(

--- a/app/src/main/java/com/cornellappdev/android/volume/data/repositories/FlyerRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/repositories/FlyerRepository.kt
@@ -1,5 +1,7 @@
 package com.cornellappdev.android.volume.data.repositories
 
+import com.apollographql.apollo3.api.ApolloResponse
+import com.cornellappdev.android.volume.DeleteFlyerMutation
 import com.cornellappdev.android.volume.FlyerByIDQuery
 import com.cornellappdev.android.volume.FlyersAfterDateQuery
 import com.cornellappdev.android.volume.FlyersBeforeDateQuery
@@ -45,6 +47,9 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
     suspend fun fetchFlyersByOrganizationSlug(slug: String): List<Flyer> =
         networkApi.fetchFlyersByOrganizationSlug(slug).dataAssertNoErrors.mapDataToFlyers()
 
+    suspend fun deleteFlyer(id: String): ApolloResponse<DeleteFlyerMutation.Data> =
+        networkApi.deleteFlyer(id)
+
     /*
     Create and remove flyer operations send
      */
@@ -65,27 +70,6 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
                 categorySlug = flyer.categorySlug,
             )
         }
-
-    // Let this one directly go to the network API so it is easier to view errors
-    suspend fun createFlyer(
-        title: String,
-        startDate: String,
-        location: String,
-        flyerURL: String,
-        endDate: String,
-        categorySlug: String,
-        imageBase64: String,
-        organizationId: String,
-    ) = networkApi.createFlyer(
-        title,
-        startDate,
-        location,
-        flyerURL,
-        endDate,
-        categorySlug,
-        imageBase64,
-        organizationId
-    )
 
     private fun FlyerByIDQuery.Data.mapDataToFlyer(): Flyer {
         val flyerData = this.getFlyerByID!!

--- a/app/src/main/java/com/cornellappdev/android/volume/data/repositories/FlyerRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/repositories/FlyerRepository.kt
@@ -4,7 +4,7 @@ import com.cornellappdev.android.volume.FlyersAfterDateQuery
 import com.cornellappdev.android.volume.FlyersBeforeDateQuery
 import com.cornellappdev.android.volume.FlyersByCategorySlugQuery
 import com.cornellappdev.android.volume.FlyersByIDsQuery
-import com.cornellappdev.android.volume.OrganizationsByCategoryQuery
+import com.cornellappdev.android.volume.FlyersByOrganizationIdQuery
 import com.cornellappdev.android.volume.SearchFlyersQuery
 import com.cornellappdev.android.volume.TrendingFlyersQuery
 import com.cornellappdev.android.volume.data.NetworkApi
@@ -37,6 +37,10 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
 
     suspend fun fetchSearchedFlyers(query: String): List<Flyer> =
         networkApi.fetchSearchedFlyers(query).dataAssertNoErrors.mapDataToFlyers()
+
+    suspend fun fetchFlyersByOrganizationId(id: String): List<Flyer> =
+        networkApi.fetchFlyersByOrganizationId(id).dataAssertNoErrors.mapDataToFlyers()
+
 
     // These functions map the apollo query types to types of the models that are in place.
     private fun SearchFlyersQuery.Data.mapDataToFlyers(): List<Flyer> =
@@ -92,6 +96,21 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
 
     private fun FlyersByCategorySlugQuery.Data.mapDataToFlyers(): List<Flyer> =
         this.getFlyersByCategorySlug.map { flyer ->
+            Flyer(
+                id = flyer.id,
+                title = flyer.title,
+                organization = flyer.organization.mapToOrganization(),
+                flyerURL = flyer.flyerURL,
+                startDate = flyer.startDate as String,
+                endDate = flyer.endDate as String,
+                imageURL = flyer.imageURL,
+                location = flyer.location,
+                categorySlug = flyer.categorySlug,
+            )
+        }
+
+    private fun FlyersByOrganizationIdQuery.Data.mapDataToFlyers(): List<Flyer> =
+        this.getFlyersByOrganizationID.map { flyer ->
             Flyer(
                 id = flyer.id,
                 title = flyer.title,
@@ -206,18 +225,15 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
         id = this.id
     )
 
-    private fun OrganizationsByCategoryQuery.Data.mapToOrganizations(): List<Organization> =
-        // TODO why do I need a non-null assertion here?
-        this.getOrganizationsByCategory!!.map {
-            Organization(
-                name = it.name,
-                categorySlug = it.categorySlug,
-                websiteURL = it.websiteURL,
-                backgroundImageURL = it.backgroundImageURL,
-                bio = it.bio,
-                id = it.id
-            )
-        }
+    private fun FlyersByOrganizationIdQuery.Organization.mapToOrganization(): Organization =
+        Organization(
+            name = this.name,
+            categorySlug = this.categorySlug,
+            websiteURL = this.websiteURL,
+            backgroundImageURL = this.backgroundImageURL,
+            bio = this.bio,
+            id = this.id
+        )
 }
 
 

--- a/app/src/main/java/com/cornellappdev/android/volume/data/repositories/FlyerRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/repositories/FlyerRepository.kt
@@ -4,7 +4,7 @@ import com.cornellappdev.android.volume.FlyersAfterDateQuery
 import com.cornellappdev.android.volume.FlyersBeforeDateQuery
 import com.cornellappdev.android.volume.FlyersByCategorySlugQuery
 import com.cornellappdev.android.volume.FlyersByIDsQuery
-import com.cornellappdev.android.volume.FlyersByOrganizationIdQuery
+import com.cornellappdev.android.volume.FlyersByOrganizationSlugQuery
 import com.cornellappdev.android.volume.SearchFlyersQuery
 import com.cornellappdev.android.volume.TrendingFlyersQuery
 import com.cornellappdev.android.volume.data.NetworkApi
@@ -38,8 +38,8 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
     suspend fun fetchSearchedFlyers(query: String): List<Flyer> =
         networkApi.fetchSearchedFlyers(query).dataAssertNoErrors.mapDataToFlyers()
 
-    suspend fun fetchFlyersByOrganizationId(id: String): List<Flyer> =
-        networkApi.fetchFlyersByOrganizationId(id).dataAssertNoErrors.mapDataToFlyers()
+    suspend fun fetchFlyersByOrganizationSlug(slug: String): List<Flyer> =
+        networkApi.fetchFlyersByOrganizationSlug(slug).dataAssertNoErrors.mapDataToFlyers()
 
 
     // These functions map the apollo query types to types of the models that are in place.
@@ -79,8 +79,8 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
         organizationId
     )
 
-    private fun FlyersByIDsQuery.Data.mapDataToFlyers(): List<Flyer> =
-        this.getFlyersByIDs.map { flyer ->
+    private fun FlyersByOrganizationSlugQuery.Data.mapDataToFlyers(): List<Flyer> =
+        this.getFlyersByOrganizationSlug.map { flyer ->
             Flyer(
                 id = flyer.id,
                 title = flyer.title,
@@ -109,8 +109,8 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
             )
         }
 
-    private fun FlyersByOrganizationIdQuery.Data.mapDataToFlyers(): List<Flyer> =
-        this.getFlyersByOrganizationID.map { flyer ->
+    private fun FlyersByIDsQuery.Data.mapDataToFlyers(): List<Flyer> =
+        this.getFlyersByIDs.map { flyer ->
             Flyer(
                 id = flyer.id,
                 title = flyer.title,
@@ -176,7 +176,8 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
         websiteURL = this.websiteURL,
         backgroundImageURL = this.backgroundImageURL,
         bio = this.bio,
-        id = this.id
+        id = this.id,
+        slug = this.slug
     )
 
     private fun FlyersByIDsQuery.Organization.mapToOrganization(): Organization = Organization(
@@ -185,7 +186,8 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
         websiteURL = this.websiteURL,
         backgroundImageURL = this.backgroundImageURL,
         bio = this.bio,
-        id = this.id
+        id = this.id,
+        slug = this.slug
     )
 
     private fun FlyersByCategorySlugQuery.Organization.mapToOrganization(): Organization =
@@ -195,7 +197,8 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
             websiteURL = this.websiteURL,
             backgroundImageURL = this.backgroundImageURL,
             bio = this.bio,
-            id = this.id
+            id = this.id,
+            slug = this.slug
         )
 
     private fun TrendingFlyersQuery.Organization.mapToOrganization(): Organization = Organization(
@@ -204,7 +207,8 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
         websiteURL = this.websiteURL,
         backgroundImageURL = this.backgroundImageURL,
         bio = this.bio,
-        id = this.id
+        id = this.id,
+        slug = this.slug
     )
 
     private fun FlyersAfterDateQuery.Organization.mapToOrganization(): Organization = Organization(
@@ -213,7 +217,8 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
         websiteURL = this.websiteURL,
         backgroundImageURL = this.backgroundImageURL,
         bio = this.bio,
-        id = this.id
+        id = this.id,
+        slug = this.slug
     )
 
     private fun FlyersBeforeDateQuery.Organization.mapToOrganization(): Organization = Organization(
@@ -222,17 +227,19 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
         websiteURL = this.websiteURL,
         backgroundImageURL = this.backgroundImageURL,
         bio = this.bio,
-        id = this.id
+        id = this.id,
+        slug = this.slug
     )
 
-    private fun FlyersByOrganizationIdQuery.Organization.mapToOrganization(): Organization =
+    private fun FlyersByOrganizationSlugQuery.Organization.mapToOrganization(): Organization =
         Organization(
             name = this.name,
             categorySlug = this.categorySlug,
             websiteURL = this.websiteURL,
             backgroundImageURL = this.backgroundImageURL,
             bio = this.bio,
-            id = this.id
+            id = this.id,
+            slug = this.slug
         )
 }
 

--- a/app/src/main/java/com/cornellappdev/android/volume/data/repositories/FlyerRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/repositories/FlyerRepository.kt
@@ -1,5 +1,6 @@
 package com.cornellappdev.android.volume.data.repositories
 
+import com.cornellappdev.android.volume.FlyerByIDQuery
 import com.cornellappdev.android.volume.FlyersAfterDateQuery
 import com.cornellappdev.android.volume.FlyersBeforeDateQuery
 import com.cornellappdev.android.volume.FlyersByCategorySlugQuery
@@ -27,6 +28,9 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
 
     suspend fun fetchFlyersByIds(ids: List<String>): List<Flyer> =
         networkApi.fetchFlyersByIds(ids).dataAssertNoErrors.mapDataToFlyers()
+
+    suspend fun fetchFlyerById(id: String): Flyer =
+        networkApi.fetchFlyerById(id).dataAssertNoErrors.mapDataToFlyer()
 
     suspend fun incrementTimesClicked(id: String) {
         networkApi.incrementTimesClicked(id)
@@ -78,6 +82,27 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
         imageBase64,
         organizationId
     )
+
+    private fun FlyerByIDQuery.Data.mapDataToFlyer(): Flyer {
+        val flyerData = this.getFlyerByID!!
+        return Flyer(
+            id = flyerData.id,
+            title = flyerData.title,
+            organization = Organization(
+                id = flyerData.organization.id,
+                categorySlug = flyerData.organization.categorySlug,
+                name = flyerData.organization.name,
+                slug = flyerData.organization.slug,
+                websiteURL = flyerData.organization.websiteURL
+            ),
+            location = flyerData.location,
+            flyerURL = flyerData.flyerURL,
+            categorySlug = flyerData.categorySlug,
+            endDate = flyerData.endDate.toString(),
+            imageURL = flyerData.imageURL,
+            startDate = flyerData.startDate.toString()
+        )
+    }
 
     private fun FlyersByOrganizationSlugQuery.Data.mapDataToFlyers(): List<Flyer> =
         this.getFlyersByOrganizationSlug.map { flyer ->

--- a/app/src/main/java/com/cornellappdev/android/volume/data/repositories/FlyerRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/repositories/FlyerRepository.kt
@@ -45,6 +45,10 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
     suspend fun fetchFlyersByOrganizationSlug(slug: String): List<Flyer> =
         networkApi.fetchFlyersByOrganizationSlug(slug).dataAssertNoErrors.mapDataToFlyers()
 
+    /*
+    Create and remove flyer operations send
+     */
+
 
     // These functions map the apollo query types to types of the models that are in place.
     private fun SearchFlyersQuery.Data.mapDataToFlyers(): List<Flyer> =

--- a/app/src/main/java/com/cornellappdev/android/volume/data/repositories/OrganizationRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/repositories/OrganizationRepository.kt
@@ -8,7 +8,20 @@ class OrganizationRepository @Inject constructor(private val networkApi: Network
     suspend fun checkAccessCode(accessCode: String, slug: String) =
         networkApi.verifyAccessCode(accessCode = accessCode, organizationSlug = slug)
 
-    suspend fun getOrganizationById(id: String) =
+    suspend fun getOrganizationBySlug(slug: String): Organization? =
+        networkApi.fetchOrganizationBySlug(slug).dataAssertNoErrors.getOrganizationBySlug?.let {
+            Organization(
+                name = it.name,
+                categorySlug = it.categorySlug,
+                websiteURL = it.websiteURL,
+                backgroundImageURL = it.backgroundImageURL,
+                bio = it.bio,
+                id = it.id,
+                slug = it.slug
+            )
+        }
+
+    suspend fun getOrganizationById(id: String): Organization? =
         networkApi.fetchOrganizationById(id).dataAssertNoErrors.getOrganizationByID?.let {
             Organization(
                 name = it.name,
@@ -16,7 +29,8 @@ class OrganizationRepository @Inject constructor(private val networkApi: Network
                 websiteURL = it.websiteURL,
                 backgroundImageURL = it.backgroundImageURL,
                 bio = it.bio,
-                id = it.id
+                id = it.id,
+                slug = it.slug,
             )
         }
 }

--- a/app/src/main/java/com/cornellappdev/android/volume/navigation/MainTabbedNavigation.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/navigation/MainTabbedNavigation.kt
@@ -425,7 +425,7 @@ private fun MainScreenNavigationConfigurations(
             val flyerId = entry.arguments?.getString("flyerId")
             FlyerUploadScreen(
                 organizationSlug = orgSlug ?: "",
-                onFlyerUploadSuccess = { navController.navigate(Routes.FLYER_SUCCESS.route) },
+                onFlyerUploadSuccess = { navController.navigate("${Routes.ORGANIZATION_HOME.route}/$orgSlug") },
                 editingFlyerId = flyerId
             )
         }
@@ -436,7 +436,7 @@ private fun MainScreenNavigationConfigurations(
             val flyerId: String? = entry.arguments?.getString("flyerId")
             FlyerUploadScreen(
                 organizationSlug = orgSlug ?: "",
-                onFlyerUploadSuccess = { navController.navigate(Routes.FLYER_SUCCESS.route) },
+                onFlyerUploadSuccess = { navController.navigate("${Routes.ORGANIZATION_HOME.route}/$orgSlug") },
                 editingFlyerId = flyerId
             )
         }

--- a/app/src/main/java/com/cornellappdev/android/volume/navigation/MainTabbedNavigation.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/navigation/MainTabbedNavigation.kt
@@ -404,13 +404,41 @@ private fun MainScreenNavigationConfigurations(
                     animationSpec = tween(durationMillis = 1000)
                 )
             }) {
-            OrganizationsLoginScreen({ navController.navigate("${Routes.UPLOAD_FLYER.route}/$it") })
+            OrganizationsLoginScreen({ navController.navigate("${Routes.ORGANIZATION_HOME.route}/$it") })
         }
-        composable(route = "${Routes.UPLOAD_FLYER.route}/{organizationId}") { entry ->
-            val orgId = entry.arguments?.getString("organizationId")
+        composable(route = "${Routes.ORGANIZATION_HOME.route}/{organizationSlug}") { entry ->
+            val orgSlug = entry.arguments?.getString("organizationSlug")
+            OrganizationHome(
+                organizationSlug = orgSlug ?: "",
+                onFlyerUploadClicked = { navController.navigate("${Routes.UPLOAD_FLYER.route}/$orgSlug") },
+                onFlyerEditClicked = { flyerId ->
+                    navController.navigate(
+                        "${Routes.UPLOAD_FLYER.route}/$orgSlug/${flyerId}"
+                    )
+                }
+            )
+        }
+        composable(
+            route = "${Routes.UPLOAD_FLYER.route}/{organizationSlug}/{flyerId}",
+        ) { entry ->
+            val orgSlug = entry.arguments?.getString("organizationSlug")
+            val flyerId = entry.arguments?.getString("flyerId")
             FlyerUploadScreen(
-                organizationId = orgId ?: "",
-                onFlyerUploadSuccess = { navController.navigate(Routes.FLYER_SUCCESS.route) })
+                organizationSlug = orgSlug ?: "",
+                onFlyerUploadSuccess = { navController.navigate(Routes.FLYER_SUCCESS.route) },
+                editingFlyerId = flyerId
+            )
+        }
+        composable(
+            route = "${Routes.UPLOAD_FLYER.route}/{organizationSlug}",
+        ) { entry ->
+            val orgSlug = entry.arguments?.getString("organizationSlug")
+            val flyerId: String? = entry.arguments?.getString("flyerId")
+            FlyerUploadScreen(
+                organizationSlug = orgSlug ?: "",
+                onFlyerUploadSuccess = { navController.navigate(Routes.FLYER_SUCCESS.route) },
+                editingFlyerId = flyerId
+            )
         }
         composable(route = Routes.FLYER_SUCCESS.route, enterTransition = {
             fadeIn(

--- a/app/src/main/java/com/cornellappdev/android/volume/navigation/MainTabbedNavigation.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/navigation/MainTabbedNavigation.kt
@@ -413,7 +413,7 @@ private fun MainScreenNavigationConfigurations(
                 onFlyerUploadClicked = { navController.navigate("${Routes.UPLOAD_FLYER.route}/$orgSlug") },
                 onFlyerEditClicked = { flyerId ->
                     navController.navigate(
-                        "${Routes.UPLOAD_FLYER.route}/$orgSlug/${flyerId}"
+                        "${Routes.UPLOAD_FLYER.route}/$orgSlug/$flyerId"
                     )
                 }
             )

--- a/app/src/main/java/com/cornellappdev/android/volume/navigation/NavigationItem.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/navigation/NavigationItem.kt
@@ -91,4 +91,5 @@ enum class Routes(override var route: String) : NavUnit {
     ORGANIZATION_LOGIN("organization_login"),
     UPLOAD_FLYER("upload_flyer"),
     FLYER_SUCCESS("flyer_success"),
+    ORGANIZATION_HOME("organization_home"),
 }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
@@ -13,13 +13,16 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
@@ -27,12 +30,15 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.CornerRadius
@@ -206,7 +212,7 @@ fun SmallFlyer(
                 url = flyer.flyerURL ?: flyer.organization.websiteURL,
                 context = LocalContext.current,
                 flyerId = flyer.id,
-                showMenuIcon = showMenuIcon,
+                onMenuItemClick = onMenuIconClick,
             )
             // Flyer title
             Text(
@@ -282,7 +288,7 @@ fun OrganizationAndIconsRow(
     url: String,
     context: Context,
     flyerId: String,
-    showMenuIcon: Boolean = false,
+    onMenuItemClick: (() -> Unit)? = null,
     flyersViewModel: FlyersViewModel = hiltViewModel(),
 ) {
     var isBookmarked by remember { mutableStateOf(false) }
@@ -313,7 +319,7 @@ fun OrganizationAndIconsRow(
         )
         Spacer(modifier = Modifier.weight(1F))
         // Bookmark icon
-        if (showMenuIcon) {
+        if (onMenuItemClick != null) {
             @Composable
             fun Circle() {
                 Box(
@@ -323,8 +329,14 @@ fun OrganizationAndIconsRow(
                             shape = CircleShape
                         )
                         .background(Color(0xFF6B6B6B))
-                ) {
-
+                        .requiredSize(3.dp)
+                )
+            }
+            Row(modifier = Modifier.clickable {
+                onMenuItemClick()
+            }, horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+                repeat(3) {
+                    Circle()
                 }
             }
         } else {
@@ -372,6 +384,43 @@ fun IconTextRow(text: String, iconId: Int, modifier: Modifier = Modifier) {
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
+    }
+}
+
+@Composable
+fun FlyerWithContextDropdown(flyer: Flyer) {
+    var contextDropdownShowing by remember { mutableStateOf(false) }
+    Box(
+        modifier = Modifier
+            .fillMaxSize(),
+        contentAlignment = Alignment.TopEnd
+    ) {
+        Box {
+            SmallFlyer(
+                isExtraSmall = false,
+                flyer = flyer,
+                onMenuIconClick = {
+                    contextDropdownShowing = true
+                }
+            )
+        }
+        Box {
+            DropdownMenu(
+                expanded = contextDropdownShowing,
+                onDismissRequest = { contextDropdownShowing = false },
+                modifier = Modifier
+                    .align(Alignment.TopEnd),  // Add this line
+            ) {
+                DropdownMenuItem(
+                    text = { Text(text = "Edit Flyer") },
+                    onClick = { /*TODO*/ }
+                )
+                DropdownMenuItem(
+                    text = { Text(text = "Remove Flyer") },
+                    onClick = { /*TODO*/ }
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
@@ -153,7 +153,7 @@ fun SmallFlyer(
     flyersViewModel: FlyersViewModel = hiltViewModel(),
     showTag: Boolean = !isExtraSmall,
     showMenuIcon: Boolean = false,
-    onMenuIconClick: () -> Unit = {},
+    onMenuIconClick: (() -> Unit)? = null,
 ) {
     val imageURL = flyer.imageURL
     val context = LocalContext.current

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
@@ -8,8 +8,10 @@ import android.net.Uri
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,6 +23,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
@@ -149,6 +152,8 @@ fun SmallFlyer(
     flyer: Flyer,
     flyersViewModel: FlyersViewModel = hiltViewModel(),
     showTag: Boolean = !isExtraSmall,
+    showMenuIcon: Boolean = false,
+    onMenuIconClick: () -> Unit = {},
 ) {
     val imageURL = flyer.imageURL
     val context = LocalContext.current
@@ -200,7 +205,8 @@ fun SmallFlyer(
                 iconSize = 20.dp,
                 url = flyer.flyerURL ?: flyer.organization.websiteURL,
                 context = LocalContext.current,
-                flyerId = flyer.id
+                flyerId = flyer.id,
+                showMenuIcon = showMenuIcon,
             )
             // Flyer title
             Text(
@@ -276,6 +282,7 @@ fun OrganizationAndIconsRow(
     url: String,
     context: Context,
     flyerId: String,
+    showMenuIcon: Boolean = false,
     flyersViewModel: FlyersViewModel = hiltViewModel(),
 ) {
     var isBookmarked by remember { mutableStateOf(false) }
@@ -306,32 +313,48 @@ fun OrganizationAndIconsRow(
         )
         Spacer(modifier = Modifier.weight(1F))
         // Bookmark icon
-        Image(
-            painter = painterResource(
-                id =
-                if (isBookmarked) R.drawable.ic_bookmark_orange_filled
-                else R.drawable.ic_bookmark_orange_empty
-            ),
-            contentDescription = null,
-            modifier = Modifier
-                .size(iconSize)
-                .clickable {
-                    if (isBookmarked) flyersViewModel.removeBookmarkedFlyer(flyerId)
-                    else flyersViewModel.addBookmarkedFlyer(flyerId)
-                    isBookmarked = !isBookmarked
+        if (showMenuIcon) {
+            @Composable
+            fun Circle() {
+                Box(
+                    Modifier
+                        .border(
+                            BorderStroke(width = 0.dp, color = Color.Transparent),
+                            shape = CircleShape
+                        )
+                        .background(Color(0xFF6B6B6B))
+                ) {
+
                 }
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        // Share icon
-        Icon(
-            painter = painterResource(id = R.drawable.ic_share_black),
-            contentDescription = null,
-            modifier = Modifier
-                .size(iconSize)
-                .clickable {
-                    shareFlyer(context = context, url = url)
-                },
-        )
+            }
+        } else {
+            Image(
+                painter = painterResource(
+                    id =
+                    if (isBookmarked) R.drawable.ic_bookmark_orange_filled
+                    else R.drawable.ic_bookmark_orange_empty
+                ),
+                contentDescription = null,
+                modifier = Modifier
+                    .size(iconSize)
+                    .clickable {
+                        if (isBookmarked) flyersViewModel.removeBookmarkedFlyer(flyerId)
+                        else flyersViewModel.addBookmarkedFlyer(flyerId)
+                        isBookmarked = !isBookmarked
+                    }
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            // Share icon
+            Icon(
+                painter = painterResource(id = R.drawable.ic_share_black),
+                contentDescription = null,
+                modifier = Modifier
+                    .size(iconSize)
+                    .clickable {
+                        shareFlyer(context = context, url = url)
+                    },
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
@@ -392,6 +392,10 @@ fun IconTextRow(text: String, iconId: Int, modifier: Modifier = Modifier) {
     }
 }
 
+/**
+ * Creates a Flyer with a context dropdown for editing and removing the Flyer.
+ * Used for the Organizations home screen, and should only be viewable by organiztions.
+ */
 @Composable
 fun FlyerWithContextDropdown(flyer: Flyer, onEditClick: () -> Unit, onRemoveClick: () -> Unit) {
     var contextDropdownShowing by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/FlyerComponents.kt
@@ -160,6 +160,7 @@ fun SmallFlyer(
     showTag: Boolean = !isExtraSmall,
     showMenuIcon: Boolean = false,
     onMenuIconClick: (() -> Unit)? = null,
+    clickAction: (() -> Unit)? = null,
 ) {
     val imageURL = flyer.imageURL
     val context = LocalContext.current
@@ -190,9 +191,13 @@ fun SmallFlyer(
         // For some reason image clickability only works when it's in a box in this case
         // This is the cover image
         Box(modifier = Modifier.clickable {
-            flyersViewModel.incrementTimesClicked(flyer.id)
+            if (clickAction == null) {
+                flyersViewModel.incrementTimesClicked(flyer.id)
 
-            onFlyerClick(flyer, flyersViewModel, openLinkLauncher)
+                onFlyerClick(flyer, flyersViewModel, openLinkLauncher)
+            } else {
+                clickAction()
+            }
         }) {
             AsyncImage(
                 model = flyer.imageURL,
@@ -388,7 +393,7 @@ fun IconTextRow(text: String, iconId: Int, modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun FlyerWithContextDropdown(flyer: Flyer) {
+fun FlyerWithContextDropdown(flyer: Flyer, onEditClick: () -> Unit, onRemoveClick: () -> Unit) {
     var contextDropdownShowing by remember { mutableStateOf(false) }
     Box(
         modifier = Modifier
@@ -401,7 +406,8 @@ fun FlyerWithContextDropdown(flyer: Flyer) {
                 flyer = flyer,
                 onMenuIconClick = {
                     contextDropdownShowing = true
-                }
+                },
+                clickAction = onEditClick
             )
         }
         Box {
@@ -413,11 +419,11 @@ fun FlyerWithContextDropdown(flyer: Flyer) {
             ) {
                 DropdownMenuItem(
                     text = { Text(text = "Edit Flyer") },
-                    onClick = { /*TODO*/ }
+                    onClick = { onEditClick() }
                 )
                 DropdownMenuItem(
                     text = { Text(text = "Remove Flyer") },
-                    onClick = { /*TODO*/ }
+                    onClick = { onRemoveClick() }
                 )
             }
         }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/VolumeGeneralComponents.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/VolumeGeneralComponents.kt
@@ -399,6 +399,41 @@ fun VolumeButton(
     }
 }
 
+/**
+ * Outlined variation of the Volume button
+ * @param text the button label
+ * @param onClick the action to perform when the button is pressed
+ * @param modifier the modifier parameter, applied to the parent most element of the button
+ */
+@Composable
+fun OutlinedVolumeButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    icon: (@Composable () -> Unit)? = null,
+) {
+    Row(
+        modifier = modifier
+            .border(width = 1.dp, shape = RoundedCornerShape(4.dp), color = VolumeOrange)
+            .clickable {
+                onClick()
+            }
+            .padding(vertical = 12.dp, horizontal = 16.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        icon?.let {
+            it()
+            Spacer(Modifier.width(8.dp))
+        }
+        Text(
+            text = text,
+            color = VolumeOrange,
+            fontFamily = lato
+        )
+    }
+}
+
 @Composable
 fun ErrorMessage(message: String) {
     Row(verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/FlyerUploadScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/FlyerUploadScreen.kt
@@ -1,7 +1,6 @@
 package com.cornellappdev.android.volume.ui.screens
 
 import android.net.Uri
-import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -330,7 +329,6 @@ fun FlyerUploadScreen(
                 sd
             }
         } catch (e: Exception) {
-            Log.d("UPLOAD", "onUploadClick: flyer upload failed, ${e.message}")
             flyerUploadViewModel.errorFlyerUpload()
         }
     }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/FlyerUploadScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/FlyerUploadScreen.kt
@@ -74,9 +74,10 @@ import java.time.format.DateTimeFormatter
 
 @Composable
 fun FlyerUploadScreen(
-    organizationId: String,
+    organizationSlug: String,
     onFlyerUploadSuccess: () -> Unit,
     flyerUploadViewModel: FlyerUploadViewModel = hiltViewModel(),
+    editingFlyerId: String? = null,
 ) {
     val context = LocalContext.current
 
@@ -97,7 +98,7 @@ fun FlyerUploadScreen(
 
     // Start by getting info about their organization
     LaunchedEffect(key1 = "launch") {
-        flyerUploadViewModel.getOrganization(organizationId)
+        flyerUploadViewModel.getOrganization(organizationSlug)
     }
 
     // Effect to update whether button is enabled based on form values
@@ -286,7 +287,7 @@ fun FlyerUploadScreen(
                                 bytes,
                                 Base64.DEFAULT
                             ),
-                            organizationId = organizationId
+                            organizationId = organizationSlug
                         )
                     }
                     sd

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/FlyerUploadScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/FlyerUploadScreen.kt
@@ -6,8 +6,6 @@ import android.util.Base64
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,9 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.Icon
@@ -28,15 +24,16 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.outlined.AccessTime
 import androidx.compose.material.icons.outlined.ArrowDropDown
+import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -45,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.cornellappdev.android.volume.ui.components.general.ErrorMessage
+import com.cornellappdev.android.volume.ui.components.general.OutlinedVolumeButton
 import com.cornellappdev.android.volume.ui.components.general.VolumeButton
 import com.cornellappdev.android.volume.ui.components.general.VolumeInputContainer
 import com.cornellappdev.android.volume.ui.components.general.VolumeLoading
@@ -81,7 +79,9 @@ fun FlyerUploadScreen(
 ) {
     val context = LocalContext.current
 
-    var flyerName by remember { mutableStateOf("") }
+    val isEditing = editingFlyerId != null
+
+    var flyerTitle by remember { mutableStateOf("") }
     var location by remember { mutableStateOf("") }
     var redirectLink: String by remember { mutableStateOf("") }
     var startDate: LocalDate? by remember { mutableStateOf(null) }
@@ -96,15 +96,43 @@ fun FlyerUploadScreen(
     var uploadEnabled by remember { mutableStateOf(false) }
     var hasTriedUpload by remember { mutableStateOf(false) }
 
-    // Start by getting info about their organization
+    // Start by getting info about their organization and potentially the Flyer if they are editing
     LaunchedEffect(key1 = "launch") {
-        flyerUploadViewModel.getOrganization(organizationSlug)
+        flyerUploadViewModel.initViewModel(
+            organizationSlug = organizationSlug,
+            flyerId = editingFlyerId,
+        )
     }
+
+    val organization = flyerUploadViewModel.orgFlow.collectAsState().value
+    val flyer = flyerUploadViewModel.flyerFlow.collectAsState().value
+    val uploadResult = flyerUploadViewModel.uploadResultFlow.collectAsState().value
+
+    DisposableEffect(key1 = flyer, effect = {
+        if (flyer is ResponseState.Success) {
+            val flyerData = flyer.data
+            flyerTitle = flyerData.title
+            location = flyerData.location
+            redirectLink = flyerData.flyerURL ?: ""
+            startDate = flyerData.startDateTime.toLocalDate()
+            endDate = flyerData.endDateTime.toLocalDate()
+            startTime = flyerData.startDateTime.toLocalTime()
+            endTime = flyerData.endDateTime.toLocalTime()
+            flyerCategory = flyerData.categorySlug
+
+            val tags = FlyerConstants.CATEGORY_SLUGS.split(",")
+            val displayedCategory = FlyerConstants.FORMATTED_TAGS.firstOrNull { s ->
+                s.replace(" ", "").replaceFirstChar { it.lowercase() } == flyerData.categorySlug
+            }
+            flyerCategory = displayedCategory ?: "Error retrieving category, select again"
+        }
+        onDispose { }
+    })
 
     // Effect to update whether button is enabled based on form values
     DisposableEffect(
         key1 = arrayOf(
-            flyerName,
+            flyerTitle,
             location,
             redirectLink,
             startDate,
@@ -124,7 +152,7 @@ fun FlyerUploadScreen(
             st
         }
 
-        uploadEnabled = flyerName.isNotBlank() &&
+        uploadEnabled = flyerTitle.isNotBlank() &&
                 location.isNotBlank() &&
                 startDate != null &&
                 endDate != null &&
@@ -132,6 +160,7 @@ fun FlyerUploadScreen(
                 endTime != null &&
                 flyerImageUri != null &&
                 flyerCategory.isNotBlank() &&
+                flyerCategory != "Error retrieving category, select again" &&
                 !hasTimeError
 
         onDispose { }
@@ -251,11 +280,11 @@ fun FlyerUploadScreen(
                 }
             if (bytes == null) {
                 currentErrorMessage = "Failed to upload flyer."
-                flyerUploadViewModel.error()
+                flyerUploadViewModel.errorFlyerUpload()
             } else if (bytes.size >= (50000000)) {
                 currentErrorMessage =
                     "Image too large, please use a lower quality image."
-                flyerUploadViewModel.error()
+                flyerUploadViewModel.errorFlyerUpload()
             } else {
                 letIfAllNotNull(startDate, endDate) { (sd, ed) ->
                     letIfAllNotNull(startTime, endTime) { (st, et) ->
@@ -273,7 +302,7 @@ fun FlyerUploadScreen(
                                 )
 
                         flyerUploadViewModel.uploadFlyer(
-                            title = flyerName,
+                            title = flyerTitle,
                             startDate = startDateString,
                             location = location,
                             flyerURL = if (redirectLink.isBlank()) "" else (if (redirectLink.startsWith(
@@ -294,7 +323,7 @@ fun FlyerUploadScreen(
                 }
             }
         } catch (ignored: Exception) {
-            flyerUploadViewModel.error()
+            flyerUploadViewModel.errorFlyerUpload()
         }
     }
 
@@ -319,8 +348,7 @@ fun FlyerUploadScreen(
         // Organization name
         Column(modifier = Modifier.padding(top = 14.dp)) {
             Text(text = "Organization", fontFamily = notoserif, fontSize = 16.sp, color = GrayFive)
-            when (val organization =
-                flyerUploadViewModel.uploadFlyerUiState.organizationInfoResult) {
+            when (organization) {
                 is ResponseState.Success -> {
                     Text(text = organization.data.name, fontSize = 24.sp, fontFamily = notoserif)
                 }
@@ -335,13 +363,28 @@ fun FlyerUploadScreen(
             }
         }
 
+        // Allow the user to delete their flyer if the user is editing
+        if (isEditing) {
+            OutlinedVolumeButton(
+                text = "Remove Flyer",
+                onClick = {/* TODO */ },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Delete,
+                    contentDescription = "Removal icon",
+                    tint = VolumeOrange
+                )
+            }
+        }
+
         // Flyer name input
         Column {
             Text(text = "Flyer Name", fontFamily = notoserif, fontSize = 16.sp, color = GrayFive)
             Spacer(Modifier.height(8.dp))
             VolumeTextField(
-                value = flyerName,
-                onValueChange = { flyerName = it },
+                value = flyerTitle,
+                onValueChange = { flyerTitle = it },
                 modifier = Modifier.height(48.dp)
             )
         }
@@ -483,47 +526,34 @@ fun FlyerUploadScreen(
         }
 
         // Upload image button
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .border(width = 1.dp, shape = RoundedCornerShape(4.dp), color = VolumeOrange)
-                .clickable {
-                    imagePickerLauncher.launch(
-                        PickVisualMediaRequest(
-                            mediaType = ActivityResultContracts.PickVisualMedia.ImageOnly
-                        )
-                    )
-                }
-                .padding(vertical = 12.dp, horizontal = 16.dp),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
+        OutlinedVolumeButton(text = fileName ?: "Select an image...", onClick = {
+            imagePickerLauncher.launch(
+                PickVisualMediaRequest(
+                    mediaType = ActivityResultContracts.PickVisualMedia.ImageOnly
+                )
+            )
+        }, icon = {
             Icon(
                 imageVector = Icons.Filled.CameraAlt,
                 contentDescription = "Camera",
                 tint = VolumeOrange,
                 modifier = Modifier.size(16.dp)
             )
-            Spacer(Modifier.width(8.dp))
-            Text(
-                text = fileName ?: "Select an image...",
-                color = VolumeOrange,
-                fontFamily = lato
-            )
-        }
+        }, modifier = Modifier.fillMaxWidth())
+
         // Upload flyer button
         Column {
             VolumeButton(
-                text = "Upload Flyer",
+                text = if (isEditing) "Edit Flyer" else "Upload Flyer",
                 onClick = { onUploadClick() },
                 enabled = uploadEnabled,
                 modifier = Modifier.fillMaxWidth()
             )
             Spacer(Modifier.height(8.dp))
-            when (val res = flyerUploadViewModel.uploadFlyerUiState.uploadFlyerResult) {
+            when (uploadResult) {
                 is ResponseState.Error -> {
                     ErrorMessage(
-                        message = res.errors.firstOrNull()?.message ?: currentErrorMessage
+                        message = uploadResult.errors.firstOrNull()?.message ?: currentErrorMessage
                     )
                 }
 

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/FlyerUploadScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/FlyerUploadScreen.kt
@@ -1,7 +1,6 @@
 package com.cornellappdev.android.volume.ui.screens
 
 import android.net.Uri
-import android.provider.OpenableColumns
 import android.util.Base64
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
@@ -55,6 +54,7 @@ import com.cornellappdev.android.volume.ui.theme.lato
 import com.cornellappdev.android.volume.ui.theme.notoserif
 import com.cornellappdev.android.volume.ui.viewmodels.FlyerUploadViewModel
 import com.cornellappdev.android.volume.util.FlyerConstants
+import com.cornellappdev.android.volume.util.deriveFileName
 import com.cornellappdev.android.volume.util.letIfAllNotNull
 import com.vanpra.composematerialdialogs.MaterialDialog
 import com.vanpra.composematerialdialogs.datetime.date.DatePickerDefaults
@@ -184,18 +184,8 @@ fun FlyerUploadScreen(
 
     // Effect to update image upload text based on flyer name
     DisposableEffect(key1 = flyerImageUri, effect = {
-        val contentResolver = context.contentResolver
         flyerImageUri?.let { uri ->
-            val cursor = contentResolver.query(uri, null, null, null, null)
-            if (cursor != null && cursor.moveToFirst()) {
-                val colIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-                if (colIndex != -1) {
-                    val displayName = cursor.getString(colIndex)
-                    fileName = displayName
-                }
-                cursor.close()
-            }
-            cursor?.close()
+            fileName = deriveFileName(uri, context)
         }
         onDispose { }
     })
@@ -281,7 +271,7 @@ fun FlyerUploadScreen(
             if (bytes == null) {
                 currentErrorMessage = "Failed to upload flyer."
                 flyerUploadViewModel.errorFlyerUpload()
-            } else if (bytes.size >= (50000000)) {
+            } else if (bytes.size >= (16_000_000)) {
                 currentErrorMessage =
                     "Image too large, please use a lower quality image."
                 flyerUploadViewModel.errorFlyerUpload()

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/FlyersScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/FlyersScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -49,6 +48,9 @@ import com.cornellappdev.android.volume.ui.theme.VolumeOrange
 import com.cornellappdev.android.volume.ui.theme.notoserif
 import com.cornellappdev.android.volume.ui.viewmodels.FlyersViewModel
 import com.cornellappdev.android.volume.util.FlyerConstants
+
+private const val NO_FLYERS_MESSAGE =
+    "If you want to see your organization's events on Volume, email us at volumeappdev@gmail.com"
 
 @Composable
 fun FlyersScreen(
@@ -70,8 +72,7 @@ fun FlyersScreen(
     }
     var expanded by remember { mutableStateOf(false) }
     val uiState = flyersViewModel.flyersUiState
-    val NO_FLYERS_MESSAGE =
-        "If you want to see your organization's events on Volume, email us at volumeappdev@gmail.com"
+
 
     LazyColumn(modifier = Modifier.padding(start = 16.dp)) {
         // Page title
@@ -353,27 +354,5 @@ fun FlyersScreen(
                 modifier = Modifier.padding(bottom = 141.dp)
             )
         }
-    }
-}
-
-@Composable
-fun NoMoreText(text: String) {
-    Row {
-        Spacer(modifier = Modifier.weight(1f))
-        Column(modifier = Modifier.width(219.dp)) {
-            Text(
-                text = text,
-                fontSize = 18.sp,
-                fontFamily = notoserif,
-                textAlign = TextAlign.Center
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            Text(
-                text = "If you want to see your organization’s events on Volume, email us at volumeappdev@gmail.com",
-                fontSize = 12.sp,
-                textAlign = TextAlign.Center
-            )
-        }
-        Spacer(modifier = Modifier.weight(1f))
     }
 }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/OrganizationHome.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/OrganizationHome.kt
@@ -50,7 +50,7 @@ fun OrganizationHome(
     onFlyerEditClicked: (flyerId: String) -> Unit,
 ) {
     var selectedTabIndex by remember { mutableStateOf(0) }
-    val tabs = listOf("Current", "Past", "Removed")
+    val tabs = listOf("Current", "Past")
     LaunchedEffect(key1 = "launch", block = {
         organizationsHomeViewModel.initViewModel(organizationSlug)
     })

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/OrganizationHome.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/OrganizationHome.kt
@@ -1,0 +1,195 @@
+package com.cornellappdev.android.volume.ui.screens
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.Tab
+import androidx.compose.material.TabRow
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CloudUpload
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.cornellappdev.android.volume.data.models.Organization
+import com.cornellappdev.android.volume.ui.components.general.ErrorState
+import com.cornellappdev.android.volume.ui.components.general.ShimmeringFlyer
+import com.cornellappdev.android.volume.ui.components.general.SmallFlyer
+import com.cornellappdev.android.volume.ui.states.ResponseState
+import com.cornellappdev.android.volume.ui.theme.VolumeOrange
+import com.cornellappdev.android.volume.ui.theme.notoserif
+import com.cornellappdev.android.volume.ui.viewmodels.OrganizationsHomeViewModel
+
+@Composable
+fun OrganizationHome(
+    organization: Organization,
+    organizationsHomeViewModel: OrganizationsHomeViewModel = hiltViewModel(),
+) {
+    var selectedTabIndex by remember { mutableStateOf(0) }
+    val tabs = listOf("Current", "Past", "Removed")
+    organizationsHomeViewModel.initViewModel(organization.id)
+
+    val currentFlyers = organizationsHomeViewModel.currentFlyersFlow.collectAsState().value
+    val pastFlyers = organizationsHomeViewModel.pastFlyersFlow.collectAsState().value
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+    ) {
+        // Page header
+        Text(
+            text = "Organization Home",
+            fontFamily = notoserif,
+            fontSize = 20.sp,
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .padding(top = 16.dp)
+        )
+
+        Spacer(modifier = Modifier.height(38.dp))
+
+        // Organization name
+        Text(text = organization.name, fontSize = 24.sp, fontFamily = notoserif)
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Upload Flyer button
+        Box(
+            modifier = Modifier
+                .requiredHeight(128.dp)
+                .fillMaxWidth()
+                .border(
+                    BorderStroke(width = 4.dp, color = Color(208, 112, 0, 52)),
+                    shape = RoundedCornerShape(4.dp)
+                )
+                .background(Color(208, 112, 0, 13))
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+                .clickable {
+                    // TODO upload Flyer
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Icon(
+                    imageVector = Icons.Outlined.CloudUpload,
+                    contentDescription = "Upload",
+                    tint = VolumeOrange,
+                    modifier = Modifier.requiredSize(24.dp),
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(text = "Upload a New Flyer", color = VolumeOrange, fontSize = 16.sp)
+            }
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        TabRow(
+            selectedTabIndex = selectedTabIndex,
+            contentColor = Color.Black,
+        ) {
+            tabs.forEachIndexed { index, text ->
+                Tab(
+                    selected = selectedTabIndex == index,
+                    onClick = { selectedTabIndex = index },
+                    text = {
+                        Text(text = text, fontSize = 16.sp, fontFamily = notoserif)
+                    },
+                    selectedContentColor = Color.White,
+                    unselectedContentColor = Color.White,
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        when (selectedTabIndex) {
+            0 -> {
+                Text(text = "Current Flyers", fontSize = 20.sp, fontFamily = notoserif)
+            }
+
+            1 -> {
+                Text(text = "Past Flyers", fontSize = 20.sp, fontFamily = notoserif)
+            }
+        }
+        LazyColumn {
+            when (selectedTabIndex) {
+                // Current Flyers
+                0 -> {
+                    when (currentFlyers) {
+                        is ResponseState.Loading -> {
+                            items(5) {
+                                ShimmeringFlyer()
+                            }
+                        }
+
+                        is ResponseState.Success -> {
+                            items(currentFlyers.data) {
+                                SmallFlyer(isExtraSmall = false, flyer = it)
+                            }
+                        }
+
+                        is ResponseState.Error -> {
+                            item {
+                                ErrorState()
+                            }
+                        }
+                    }
+                }
+                // Past Flyers
+                1 -> {
+                    when (pastFlyers) {
+                        is ResponseState.Loading -> {
+                            items(5) {
+                                ShimmeringFlyer()
+                            }
+                        }
+
+                        is ResponseState.Success -> {
+                            items(pastFlyers.data) {
+                                SmallFlyer(isExtraSmall = false, flyer = it)
+                            }
+                        }
+
+                        is ResponseState.Error -> {
+                            item {
+                                ErrorState()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun OrganizationHomePreview() {
+    OrganizationHome(
+        organization = Organization(
+            name = "Women in Computing at Cornell",
+            id = "",
+            categorySlug = "wicc",
+            websiteURL = "",
+        )
+    )
+}

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/OrganizationHome.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/OrganizationHome.kt
@@ -114,6 +114,7 @@ fun OrganizationHome(
             }
         }
         Spacer(modifier = Modifier.height(24.dp))
+        // Tabbed Flyers view
         TabRow(
             selectedTabIndex = selectedTabIndex,
             contentColor = Color.Black,
@@ -145,6 +146,7 @@ fun OrganizationHome(
                 Text(text = "Past Flyers", fontSize = 20.sp, fontFamily = notoserif)
             }
         }
+        Spacer(Modifier.height(16.dp))
         LazyColumn {
             when (selectedTabIndex) {
                 // Current Flyers
@@ -158,7 +160,13 @@ fun OrganizationHome(
 
                         is ResponseState.Success -> {
                             items(currentFlyers.data) {
-                                FlyerWithContextDropdown(flyer = it)
+                                FlyerWithContextDropdown(
+                                    flyer = it,
+                                    onEditClick = { onFlyerEditClicked(it.id) },
+                                    onRemoveClick = {
+                                        // TODO
+                                    }
+                                )
                             }
                         }
 
@@ -180,7 +188,12 @@ fun OrganizationHome(
 
                         is ResponseState.Success -> {
                             items(pastFlyers.data) {
-                                FlyerWithContextDropdown(flyer = it)
+                                FlyerWithContextDropdown(
+                                    flyer = it,
+                                    onEditClick = { onFlyerEditClicked(it.id) },
+                                    onRemoveClick = {
+                                        // TODO
+                                    })
                             }
                         }
 

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/OrganizationHome.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/OrganizationHome.kt
@@ -35,8 +35,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.cornellappdev.android.volume.ui.components.general.ErrorState
+import com.cornellappdev.android.volume.ui.components.general.FlyerWithContextDropdown
 import com.cornellappdev.android.volume.ui.components.general.ShimmeringFlyer
-import com.cornellappdev.android.volume.ui.components.general.SmallFlyer
 import com.cornellappdev.android.volume.ui.states.ResponseState
 import com.cornellappdev.android.volume.ui.theme.VolumeOrange
 import com.cornellappdev.android.volume.ui.theme.notoserif
@@ -158,7 +158,7 @@ fun OrganizationHome(
 
                         is ResponseState.Success -> {
                             items(currentFlyers.data) {
-                                SmallFlyer(isExtraSmall = false, flyer = it)
+                                FlyerWithContextDropdown(flyer = it)
                             }
                         }
 
@@ -180,7 +180,7 @@ fun OrganizationHome(
 
                         is ResponseState.Success -> {
                             items(pastFlyers.data) {
-                                SmallFlyer(isExtraSmall = false, flyer = it)
+                                FlyerWithContextDropdown(flyer = it)
                             }
                         }
 

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/OrganizationsLoginScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/OrganizationsLoginScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Checkbox
 import androidx.compose.material.CheckboxDefaults
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -37,7 +36,6 @@ import com.cornellappdev.android.volume.ui.theme.lato
 import com.cornellappdev.android.volume.ui.theme.notoserif
 import com.cornellappdev.android.volume.ui.viewmodels.OrganizationLoginViewModel
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun OrganizationsLoginScreen(
     onSuccessfulLogin: (orgId: String) -> Unit,
@@ -132,7 +130,7 @@ fun OrganizationsLoginScreen(
         when (val res =
             organizationLoginViewModel.organizationsLoginUiState.checkAccessCodeResult) {
             is ResponseState.Success -> {
-                onSuccessfulLogin(res.data.id)
+                onSuccessfulLogin(res.data.slug)
             }
 
             is ResponseState.Error -> {

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/states/ApiResponseState.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/states/ApiResponseState.kt
@@ -5,7 +5,7 @@ package com.cornellappdev.android.volume.ui.states
  */
 sealed class ResponseState<out T> {
     object Loading : ResponseState<Nothing>()
-    data class Error(val errors: List<com.apollographql.apollo3.api.Error>) :
+    data class Error(val errors: List<com.apollographql.apollo3.api.Error> = listOf()) :
         ResponseState<Nothing>()
 
     data class Success<T>(val data: T) : ResponseState<T>()

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/FlyerUploadViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/FlyerUploadViewModel.kt
@@ -2,6 +2,7 @@ package com.cornellappdev.android.volume.ui.viewmodels
 
 import android.content.Context
 import android.net.Uri
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cornellappdev.android.volume.data.NetworkApi
@@ -11,6 +12,7 @@ import com.cornellappdev.android.volume.data.repositories.FlyerRepository
 import com.cornellappdev.android.volume.data.repositories.OrganizationRepository
 import com.cornellappdev.android.volume.ui.states.ResponseState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -60,9 +62,16 @@ class FlyerUploadViewModel @Inject constructor
     }
 
     fun uploadFlyer(flyer: Flyer, imageUri: Uri?, context: Context, isUpdating: Boolean) =
-        viewModelScope.launch {
-            val result = networkApi.mutateFlyer(flyer, imageUri, context, isUpdating = isUpdating)
-            _uploadResult.value =
-                if (result) ResponseState.Success(flyer) else ResponseState.Error()
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val result =
+                    networkApi.mutateFlyer(flyer, imageUri, context, isUpdating = isUpdating)
+                _uploadResult.value =
+                    if (result) ResponseState.Success(flyer) else ResponseState.Error()
+            } catch (e: Exception) {
+                Log.d("UPLOAD", "uploadFlyer: $e, ${e.stackTraceToString()}")
+                _uploadResult.value = ResponseState.Error()
+            }
+
         }
 }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/FlyerUploadViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/FlyerUploadViewModel.kt
@@ -45,7 +45,7 @@ class FlyerUploadViewModel @Inject constructor
         }
         try {
             flyerId?.let {
-                _flyerFlow.value = ResponseState.Success(flyersRepository.fetchFlyerById(flyerId))
+                _flyerFlow.value = ResponseState.Success(flyersRepository.fetchFlyerById(it))
             }
         } catch (_: Exception) {
             _flyerFlow.value = ResponseState.Error()

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/FlyerUploadViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/FlyerUploadViewModel.kt
@@ -27,18 +27,17 @@ class FlyerUploadViewModel @Inject constructor
     var uploadFlyerUiState by mutableStateOf(FlyerUploadUiState())
         private set
 
-    fun getOrganization(id: String) = viewModelScope.launch {
+    fun getOrganization(slug: String) = viewModelScope.launch {
         uploadFlyerUiState = try {
             uploadFlyerUiState.copy(
                 organizationInfoResult = ResponseState.Success(
-                    organizationsRepository.getOrganizationById(
-                        id
-                    )!!
+                    // Non-null assertion is ok since we are inside try catch
+                    organizationsRepository.getOrganizationBySlug(slug)!!
                 )
             )
         } catch (e: Exception) {
             uploadFlyerUiState.copy(
-                organizationInfoResult = ResponseState.Error(listOf())
+                organizationInfoResult = ResponseState.Error()
             )
         }
     }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/FlyerUploadViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/FlyerUploadViewModel.kt
@@ -1,15 +1,15 @@
 package com.cornellappdev.android.volume.ui.viewmodels
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.cornellappdev.android.volume.data.models.Flyer
 import com.cornellappdev.android.volume.data.models.Organization
 import com.cornellappdev.android.volume.data.repositories.FlyerRepository
 import com.cornellappdev.android.volume.data.repositories.OrganizationRepository
 import com.cornellappdev.android.volume.ui.states.ResponseState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -19,33 +19,40 @@ class FlyerUploadViewModel @Inject constructor
     private val organizationsRepository: OrganizationRepository,
     private val flyersRepository: FlyerRepository,
 ) : ViewModel() {
-    data class FlyerUploadUiState(
-        val uploadFlyerResult: ResponseState<String> = ResponseState.Loading,
-        val organizationInfoResult: ResponseState<Organization> = ResponseState.Loading,
-    )
+    private val _orgFlow: MutableStateFlow<ResponseState<Organization>> =
+        MutableStateFlow(ResponseState.Loading)
+    val orgFlow = _orgFlow.asStateFlow()
 
-    var uploadFlyerUiState by mutableStateOf(FlyerUploadUiState())
-        private set
+    private val _flyerFlow: MutableStateFlow<ResponseState<Flyer>> =
+        MutableStateFlow(ResponseState.Loading)
+    val flyerFlow = _flyerFlow.asStateFlow()
 
-    fun getOrganization(slug: String) = viewModelScope.launch {
-        uploadFlyerUiState = try {
-            uploadFlyerUiState.copy(
-                organizationInfoResult = ResponseState.Success(
-                    // Non-null assertion is ok since we are inside try catch
-                    organizationsRepository.getOrganizationBySlug(slug)!!
-                )
-            )
-        } catch (e: Exception) {
-            uploadFlyerUiState.copy(
-                organizationInfoResult = ResponseState.Error()
-            )
+    private val _uploadResult: MutableStateFlow<ResponseState<Flyer>> =
+        MutableStateFlow(ResponseState.Loading)
+    val uploadResultFlow = _uploadResult.asStateFlow()
+
+    fun initViewModel(organizationSlug: String, flyerId: String?) = viewModelScope.launch {
+        try {
+            _orgFlow.value =
+                ResponseState.Success(organizationsRepository.getOrganizationBySlug(organizationSlug)!!)
+        } catch (_: Exception) {
+            _orgFlow.value = ResponseState.Error()
+        }
+        try {
+            flyerId?.let {
+                _flyerFlow.value = ResponseState.Success(flyersRepository.fetchFlyerById(flyerId))
+            }
+        } catch (_: Exception) {
+            _flyerFlow.value = ResponseState.Error()
         }
     }
 
-    fun error() {
-        uploadFlyerUiState = uploadFlyerUiState.copy(
-            uploadFlyerResult = ResponseState.Error(listOf())
-        )
+    /**
+     * Updates the Flyer view model to show an error state for the upload result. Even though this
+     * does violate encapsulation in a way,
+     */
+    fun errorFlyerUpload() {
+        _uploadResult.value = ResponseState.Error()
     }
 
     fun uploadFlyer(
@@ -70,14 +77,28 @@ class FlyerUploadViewModel @Inject constructor
                 organizationId
             )
             res.errors?.let {
-                uploadFlyerUiState = uploadFlyerUiState.copy(
-                    uploadFlyerResult = ResponseState.Error(it)
-                )
+                _uploadResult.value = ResponseState.Error(it)
             }
             res.data?.let {
                 val createdFlyer = it.createFlyer
-                uploadFlyerUiState = uploadFlyerUiState.copy(
-                    uploadFlyerResult = ResponseState.Success(title)
+                _uploadResult.value = ResponseState.Success(
+                    Flyer(
+                        id = createdFlyer.id,
+                        categorySlug = createdFlyer.categorySlug,
+                        startDate = createdFlyer.startDate.toString(),
+                        endDate = createdFlyer.endDate.toString(),
+                        flyerURL = createdFlyer.flyerURL,
+                        imageURL = createdFlyer.imageURL,
+                        location = createdFlyer.location,
+                        organization = Organization(
+                            id = createdFlyer.organization.id,
+                            categorySlug = createdFlyer.organization.categorySlug,
+                            name = createdFlyer.organization.name,
+                            slug = createdFlyer.organization.slug,
+                            websiteURL = createdFlyer.organization.websiteURL
+                        ),
+                        title = createdFlyer.title
+                    )
                 )
             }
         }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/FlyerUploadViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/FlyerUploadViewModel.kt
@@ -2,7 +2,6 @@ package com.cornellappdev.android.volume.ui.viewmodels
 
 import android.content.Context
 import android.net.Uri
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cornellappdev.android.volume.data.NetworkApi
@@ -69,9 +68,7 @@ class FlyerUploadViewModel @Inject constructor
                 _uploadResult.value =
                     if (result) ResponseState.Success(flyer) else ResponseState.Error()
             } catch (e: Exception) {
-                Log.d("UPLOAD", "uploadFlyer: $e, ${e.stackTraceToString()}")
                 _uploadResult.value = ResponseState.Error()
             }
-
         }
 }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/OrganizationLoginViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/OrganizationLoginViewModel.kt
@@ -59,7 +59,8 @@ class OrganizationLoginViewModel @Inject constructor
                             name = it.name,
                             categorySlug = it.categorySlug,
                             websiteURL = it.websiteURL,
-                            id = it.id
+                            id = it.id,
+                            slug = it.slug
                         )
                     )
                 )

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/OrganizationsHomeViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/OrganizationsHomeViewModel.kt
@@ -1,0 +1,62 @@
+package com.cornellappdev.android.volume.ui.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.cornellappdev.android.volume.data.models.Flyer
+import com.cornellappdev.android.volume.data.repositories.FlyerRepository
+import com.cornellappdev.android.volume.data.repositories.OrganizationRepository
+import com.cornellappdev.android.volume.ui.states.ResponseState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.time.LocalDateTime
+import javax.inject.Inject
+
+@HiltViewModel
+class OrganizationsHomeViewModel @Inject constructor(
+    private val organizationRepository: OrganizationRepository,
+    private val flyerRepository: FlyerRepository,
+) : ViewModel() {
+
+    private val _orgFlyersFlow: MutableStateFlow<ResponseState<List<Flyer>>> =
+        MutableStateFlow(ResponseState.Loading)
+
+    private val orgFlyersFlow: StateFlow<ResponseState<List<Flyer>>> = _orgFlyersFlow.asStateFlow()
+
+    val currentFlyersFlow = orgFlyersFlow.map { apiResponse ->
+        when (apiResponse) {
+            ResponseState.Loading -> ResponseState.Loading
+            is ResponseState.Error -> ResponseState.Error()
+            is ResponseState.Success -> {
+                val flyers = apiResponse.data
+                ResponseState.Success(flyers.filter { it.endDateTime >= LocalDateTime.now() })
+            }
+        }
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, ResponseState.Loading)
+
+    val pastFlyersFlow: StateFlow<ResponseState<List<Flyer>>> = orgFlyersFlow.map { apiResponse ->
+        when (apiResponse) {
+            ResponseState.Loading -> ResponseState.Loading
+            is ResponseState.Error -> ResponseState.Error()
+            is ResponseState.Success -> {
+                val flyers = apiResponse.data
+                ResponseState.Success(flyers.filter { it.endDateTime < LocalDateTime.now() })
+            }
+        }
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, ResponseState.Loading)
+
+    fun initViewModel(organizationId: String) = viewModelScope.launch {
+        try {
+            _orgFlyersFlow.value =
+                ResponseState.Success(flyerRepository.fetchFlyersByOrganizationId(organizationId))
+        } catch (_: Exception) {
+            _orgFlyersFlow.value = ResponseState.Error()
+        }
+    }
+
+}

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/OrganizationsHomeViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/OrganizationsHomeViewModel.kt
@@ -32,8 +32,6 @@ class OrganizationsHomeViewModel @Inject constructor(
     private val _orgFlow: MutableStateFlow<ResponseState<Organization>> =
         MutableStateFlow(ResponseState.Loading)
 
-    val orgFlow = _orgFlow.asStateFlow()
-
     private val _deletionResponseFlow: MutableStateFlow<ResponseState<Boolean>> =
         MutableStateFlow(ResponseState.Loading)
 
@@ -81,7 +79,7 @@ class OrganizationsHomeViewModel @Inject constructor(
         }
         response.data?.let {
             _deletionResponseFlow.value = ResponseState.Success(true)
-            val currentOrganization = orgFlow.value
+            val currentOrganization = _orgFlow.value
             if (currentOrganization is ResponseState.Success) {
                 reloadFlyers(currentOrganization.data.slug)
             }

--- a/app/src/main/java/com/cornellappdev/android/volume/util/GeneralUtil.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/util/GeneralUtil.kt
@@ -1,7 +1,24 @@
 package com.cornellappdev.android.volume.util
 
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+
 inline fun <T : Any, R : Any> letIfAllNotNull(vararg arguments: T?, block: (List<T>) -> R): R? {
     return if (arguments.all { it != null }) {
         block(arguments.filterNotNull())
     } else null
+}
+
+fun deriveFileName(uri: Uri, context: Context): String? {
+    val cursor = context.contentResolver.query(uri, null, null, null, null)
+    if (cursor != null && cursor.moveToFirst()) {
+        val colIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+        if (colIndex != -1) {
+            return cursor.getString(colIndex)
+        }
+        cursor.close()
+    }
+    cursor?.close()
+    return null
 }

--- a/app/src/main/java/com/cornellappdev/android/volume/util/GeneralUtil.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/util/GeneralUtil.kt
@@ -15,7 +15,9 @@ fun deriveFileName(uri: Uri, context: Context): String? {
     if (cursor != null && cursor.moveToFirst()) {
         val colIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
         if (colIndex != -1) {
-            return cursor.getString(colIndex)
+            val filename = cursor.getString(colIndex)
+            cursor.close()
+            return filename
         }
         cursor.close()
     }


### PR DESCRIPTION
## Overview

This PR adds the organizations home screen to Volume. This allows organizations to see their flyers and remove flyers they may not want. Editing is coming soon, but it is urgent that we fix the issue of image uploading not working so organizations are able to upload Flyers. This PR includes the refactored upload code which appears to be working from my testing.


## Changes Made
- Added organizations home screen
- Used Flow architecture for any new networking code.
- Refactored upload for Flyers to use a `POST` request with form data to an express endpoint instead of GraphQL. 


## Test Coverage
- I tested creating a flyer and viewing the organizations home, as well as making sure that things properly update. Everything works as I expected.


## Next Steps
- Add support for editing Flyers


### Organizations home
 <img src="https://github.com/cuappdev/volume-compose-android/assets/58796478/dc30987e-b1ef-4d46-bfa4-fd4a19512d80" width=400/>  
 <img src="https://github.com/cuappdev/volume-compose-android/assets/58796478/63787605-3e92-49ce-aae6-fcb50e2d2f21" width=400/>  