### PR TITLE
Editing for Flyers

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,8 @@ android {
         applicationId "com.cornellappdev.android.volume"
         minSdk 27
         targetSdk 33
-        versionCode 14
-        versionName "1.2.9"
+        versionCode 15
+        versionName "1.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "FEEDBACK_FORM", secretsProperties['FEEDBACK_FORM'])

--- a/app/src/main/java/com/cornellappdev/android/volume/navigation/MainTabbedNavigation.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/navigation/MainTabbedNavigation.kt
@@ -408,7 +408,7 @@ private fun MainScreenNavigationConfigurations(
         }
         composable(route = "${Routes.ORGANIZATION_HOME.route}/{organizationSlug}") { entry ->
             val orgSlug = entry.arguments?.getString("organizationSlug")
-            OrganizationHome(
+            OrganizationHomeScreen(
                 organizationSlug = orgSlug ?: "",
                 onFlyerUploadClicked = { navController.navigate("${Routes.UPLOAD_FLYER.route}/$orgSlug") },
                 onFlyerEditClicked = { flyerId ->
@@ -425,7 +425,7 @@ private fun MainScreenNavigationConfigurations(
             val flyerId = entry.arguments?.getString("flyerId")
             FlyerUploadScreen(
                 organizationSlug = orgSlug ?: "",
-                onFlyerUploadSuccess = { navController.navigate("${Routes.ORGANIZATION_HOME.route}/$orgSlug") },
+                onFlyerChangeSuccess = { navController.navigate("${Routes.ORGANIZATION_HOME.route}/$orgSlug") },
                 editingFlyerId = flyerId
             )
         }
@@ -436,7 +436,7 @@ private fun MainScreenNavigationConfigurations(
             val flyerId: String? = entry.arguments?.getString("flyerId")
             FlyerUploadScreen(
                 organizationSlug = orgSlug ?: "",
-                onFlyerUploadSuccess = { navController.navigate("${Routes.ORGANIZATION_HOME.route}/$orgSlug") },
+                onFlyerChangeSuccess = { navController.navigate("${Routes.ORGANIZATION_HOME.route}/$orgSlug") },
                 editingFlyerId = flyerId
             )
         }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/FlyerUploadScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/FlyerUploadScreen.kt
@@ -23,8 +23,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.outlined.AccessTime
 import androidx.compose.material.icons.outlined.ArrowDropDown
+import androidx.compose.material.icons.outlined.Cancel
 import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -93,6 +96,7 @@ fun FlyerUploadScreen(
     var flyerCategory: String by remember { mutableStateOf("") }
     var hasTimeError: Boolean by remember { mutableStateOf(false) }
     var currentErrorMessage: String by remember { mutableStateOf("Flyer upload failed") }
+    var alertDialogShowing: Boolean by remember { mutableStateOf(false) }
 
     var uploadEnabled by remember { mutableStateOf(false) }
     var hasTriedUpload by remember { mutableStateOf(false) }
@@ -280,6 +284,31 @@ fun FlyerUploadScreen(
         }
     }
 
+    // Dialog for delete confirmation
+    if (alertDialogShowing) {
+        AlertDialog(
+            onDismissRequest = { alertDialogShowing = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    alertDialogShowing = false
+                    flyerUploadViewModel.deleteFlyer(id = editingFlyerId ?: "")
+                }) {
+                    Text(text = "Confirm")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { alertDialogShowing = false }) {
+                    Text(text = "Dismiss")
+                }
+            },
+            title = { Text(text = "Remove Flyer?") },
+            icon = { Icon(imageVector = Icons.Outlined.Cancel, contentDescription = "Cancel") },
+            text = {
+                Text(text = "Removing a flyer will delete it from Volume’s feed, but you can always repost the flyer later.")
+            }
+        )
+    }
+
     // Set up upload functionality
     fun onUploadClick() {
         hasTriedUpload = true
@@ -390,7 +419,7 @@ fun FlyerUploadScreen(
         if (isEditing) {
             OutlinedVolumeButton(
                 text = "Remove Flyer",
-                onClick = { flyerUploadViewModel.deleteFlyer(editingFlyerId ?: "") },
+                onClick = { alertDialogShowing = true },
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Icon(

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/OrganizationHomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/OrganizationHomeScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.cornellappdev.android.volume.ui.components.general.ErrorState
 import com.cornellappdev.android.volume.ui.components.general.FlyerWithContextDropdown
+import com.cornellappdev.android.volume.ui.components.general.NothingToShowMessage
 import com.cornellappdev.android.volume.ui.components.general.ShimmeringFlyer
 import com.cornellappdev.android.volume.ui.states.ResponseState
 import com.cornellappdev.android.volume.ui.theme.VolumeOrange
@@ -48,7 +49,7 @@ import com.cornellappdev.android.volume.ui.theme.notoserif
 import com.cornellappdev.android.volume.ui.viewmodels.OrganizationsHomeViewModel
 
 @Composable
-fun OrganizationHome(
+fun OrganizationHomeScreen(
     organizationSlug: String,
     organizationsHomeViewModel: OrganizationsHomeViewModel = hiltViewModel(),
     onFlyerUploadClicked: () -> Unit,
@@ -162,7 +163,7 @@ fun OrganizationHome(
         // Tabbed Flyers view
         TabRow(
             selectedTabIndex = selectedTabIndex,
-            contentColor = Color.Black,
+            contentColor = VolumeOrange,
         ) {
             tabs.forEachIndexed { index, text ->
                 Tab(
@@ -205,15 +206,20 @@ fun OrganizationHome(
                         }
 
                         is ResponseState.Success -> {
+                            if (currentFlyers.data.isEmpty()) {
+                                item {
+                                    Spacer(Modifier.height(100.dp))
+                                    NothingToShowMessage(
+                                        title = "No current flyers",
+                                        message = "If you want to see your event here, upload a flyer"
+                                    )
+                                }
+                            }
                             items(currentFlyers.data) {
                                 FlyerWithContextDropdown(
                                     flyer = it,
                                     onEditClick = {
-                                        Toast.makeText(
-                                            context,
-                                            "Editing is coming soon!",
-                                            Toast.LENGTH_LONG
-                                        ).show()
+                                        onFlyerEditClicked(it.id)
                                     },
                                     onRemoveClick = {
                                         mostRecentlyClickedFlyerId = it.id
@@ -241,6 +247,15 @@ fun OrganizationHome(
                         }
 
                         is ResponseState.Success -> {
+                            if (pastFlyers.data.isEmpty()) {
+                                item {
+                                    Spacer(Modifier.height(100.dp))
+                                    NothingToShowMessage(
+                                        title = "No past flyers",
+                                        message = "If you want to see your event here, upload a flyer"
+                                    )
+                                }
+                            }
                             items(pastFlyers.data) {
                                 FlyerWithContextDropdown(
                                     flyer = it,

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/FlyerUploadViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/FlyerUploadViewModel.kt
@@ -36,6 +36,10 @@ class FlyerUploadViewModel @Inject constructor
         MutableStateFlow(ResponseState.Loading)
     val uploadResultFlow = _uploadResult.asStateFlow()
 
+    private val _deleteResult: MutableStateFlow<ResponseState<Boolean>> =
+        MutableStateFlow(ResponseState.Loading)
+    val deleteResultFlow = _deleteResult.asStateFlow()
+
     fun initViewModel(organizationSlug: String, flyerId: String?) = viewModelScope.launch {
         try {
             _orgFlow.value =
@@ -71,4 +75,19 @@ class FlyerUploadViewModel @Inject constructor
                 _uploadResult.value = ResponseState.Error()
             }
         }
+
+    fun deleteFlyer(id: String) = viewModelScope.launch {
+        try {
+            val response = networkApi.deleteFlyer(id)
+            val errors = response.errors
+            if (!errors.isNullOrEmpty()) {
+                _deleteResult.value = ResponseState.Error(errors)
+            } else {
+                response.dataAssertNoErrors
+                _deleteResult.value = ResponseState.Success(true)
+            }
+        } catch (_: Exception) {
+            _deleteResult.value = ResponseState.Error()
+        }
+    }
 }


### PR DESCRIPTION
## Overview

This PR focuses on adding support for editing flyers and deleting Flyers from the upload page.

## Changes made
- Fixed tab color to match design
- Enabled editing screen
- Fixed deletion functionality on editing screen
- Added deletion state to upload view model
- Added deletion confirmation modal on upload page
- Added empty states to organizations home screen if the organization has not uploaded flyers.

## Test coverage

Tested using Android emulator and everything works as expected.

## Screenshots

<img src="https://github.com/cuappdev/volume-compose-android/assets/58796478/9ecb861d-d61d-4ffd-98b3-161c14501490" width=400 />


<img src="https://github.com/cuappdev/volume-compose-android/assets/58796478/beff4ad2-cfcb-41a0-9e11-e7a09904e561" width=400 />

<img src="https://github.com/cuappdev/volume-compose-android/assets/58796478/5d5c3323-e495-489e-a433-15c91da634ba" width=400 />
