### PR TITLE
Organizations Viewing Page

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,8 @@ android {
         applicationId "com.cornellappdev.android.volume"
         minSdk 27
         targetSdk 33
-        versionCode 15
-        versionName "1.3"
+        versionCode 16
+        versionName "1.4"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "FEEDBACK_FORM", secretsProperties['FEEDBACK_FORM'])

--- a/app/src/main/graphql/com/cornellappdev/android/volume/queries.graphql
+++ b/app/src/main/graphql/com/cornellappdev/android/volume/queries.graphql
@@ -70,6 +70,21 @@ query AllPublications {
     }
 }
 
+query AllOrganizations {
+    getAllOrganizations {
+        id
+        backgroundImageURL
+        bio
+        categorySlug
+        name
+        profileImageURL
+        slug
+        shoutouts
+        websiteURL
+        clicks
+    }
+}
+
 query PublicationBySlug($slug: String!) {
     getPublicationBySlug(slug: $slug) {
         backgroundImageURL
@@ -952,6 +967,9 @@ query GetUser($uuid: String!) {
         followedPublications {
             slug
         }
+        followedOrganizations {
+            slug
+        }
         weeklyDebrief {
             uuid
             creationDate
@@ -975,6 +993,9 @@ mutation CreateUser($deviceType: String!, $followedPublications: [String!]!, $de
         followedPublications {
             slug
         }
+        followedOrganizations {
+            slug
+        }
     }
 }
 
@@ -984,12 +1005,42 @@ mutation FollowPublication($slug: String!, $uuid: String!) {
         followedPublications {
             slug
         }
+        followedOrganizations {
+            slug
+        }
+    }
+}
+
+mutation FollowOrganization($slug: String!, $uuid: String!) {
+    followOrganization(slug: $slug, uuid: $uuid) {
+        uuid
+        followedOrganizations {
+            slug
+        }
+        followedPublications {
+            slug
+        }
     }
 }
 
 mutation UnfollowPublication($slug: String!, $uuid: String!) {
     unfollowPublication(slug: $slug, uuid: $uuid) {
         uuid
+        followedPublications {
+            slug
+        }
+        followedOrganizations {
+            slug
+        }
+    }
+}
+
+mutation UnfollowOrganization($slug: String!, $uuid: String!) {
+    unfollowOrganization(slug: $slug, uuid: $uuid) {
+        uuid
+        followedOrganizations {
+            slug
+        }
         followedPublications {
             slug
         }

--- a/app/src/main/java/com/cornellappdev/android/volume/data/NetworkingApi.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/NetworkingApi.kt
@@ -7,6 +7,7 @@ import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Optional
 import com.cornellappdev.android.volume.AllArticlesQuery
 import com.cornellappdev.android.volume.AllMagazinesQuery
+import com.cornellappdev.android.volume.AllOrganizationsQuery
 import com.cornellappdev.android.volume.AllPublicationSlugsQuery
 import com.cornellappdev.android.volume.AllPublicationsQuery
 import com.cornellappdev.android.volume.ArticleByIDQuery
@@ -25,6 +26,7 @@ import com.cornellappdev.android.volume.FlyersBeforeDateQuery
 import com.cornellappdev.android.volume.FlyersByCategorySlugQuery
 import com.cornellappdev.android.volume.FlyersByIDsQuery
 import com.cornellappdev.android.volume.FlyersByOrganizationSlugQuery
+import com.cornellappdev.android.volume.FollowOrganizationMutation
 import com.cornellappdev.android.volume.FollowPublicationMutation
 import com.cornellappdev.android.volume.GetUserQuery
 import com.cornellappdev.android.volume.IncrementMagazineShoutoutsMutation
@@ -44,6 +46,7 @@ import com.cornellappdev.android.volume.SearchMagazinesQuery
 import com.cornellappdev.android.volume.ShuffledArticlesByPublicationSlugsQuery
 import com.cornellappdev.android.volume.TrendingArticlesQuery
 import com.cornellappdev.android.volume.TrendingFlyersQuery
+import com.cornellappdev.android.volume.UnfollowOrganizationMutation
 import com.cornellappdev.android.volume.UnfollowPublicationMutation
 import com.cornellappdev.android.volume.data.models.Flyer
 import com.cornellappdev.android.volume.util.deriveFileName
@@ -69,6 +72,9 @@ class NetworkApi @Inject constructor(private val apolloClient: ApolloClient) {
 
     suspend fun fetchAllPublications(): ApolloResponse<AllPublicationsQuery.Data> =
         apolloClient.query(AllPublicationsQuery()).execute()
+
+    suspend fun fetchAllOrganizations(): ApolloResponse<AllOrganizationsQuery.Data> =
+        apolloClient.query(AllOrganizationsQuery()).execute()
 
     suspend fun fetchAllPublicationSlugs(): ApolloResponse<AllPublicationSlugsQuery.Data> =
         apolloClient.query(AllPublicationSlugsQuery()).execute()
@@ -312,11 +318,23 @@ class NetworkApi @Inject constructor(private val apolloClient: ApolloClient) {
     ): ApolloResponse<FollowPublicationMutation.Data> =
         apolloClient.mutation(FollowPublicationMutation(slug, uuid)).execute()
 
+    suspend fun followOrganization(
+        slug: String,
+        uuid: String,
+    ): ApolloResponse<FollowOrganizationMutation.Data> =
+        apolloClient.mutation(FollowOrganizationMutation(slug, uuid)).execute()
+
     suspend fun unfollowPublication(
         slug: String,
         uuid: String,
     ): ApolloResponse<UnfollowPublicationMutation.Data> =
         apolloClient.mutation(UnfollowPublicationMutation(slug, uuid)).execute()
+
+    suspend fun unfollowOrganization(
+        slug: String,
+        uuid: String,
+    ): ApolloResponse<UnfollowOrganizationMutation.Data> =
+        apolloClient.mutation(UnfollowOrganizationMutation(slug, uuid)).execute()
 
     suspend fun readArticle(
         articleId: String,

--- a/app/src/main/java/com/cornellappdev/android/volume/data/models/Organization.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/models/Organization.kt
@@ -5,9 +5,10 @@ data class Organization(
     val id: String,
     val categorySlug: String,
     val websiteURL: String,
-    val backgroundImageURL: String? = null,
-    val bio: String? = null,
+    val backgroundImageURL: String?,
+    val bio: String?,
     val slug: String,
+    val profileImageURL: String?,
 )
 
 val organizationTypes = listOf(

--- a/app/src/main/java/com/cornellappdev/android/volume/data/models/Social.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/models/Social.kt
@@ -10,7 +10,7 @@ import com.cornellappdev.android.volume.R
  */
 data class Social(
     val social: String,
-    val url: String
+    val url: String,
 ) {
     companion object {
         val formattedSocialNameMap = mapOf(
@@ -18,7 +18,8 @@ data class Social(
             "facebook" to "Facebook",
             "linkedin" to "LinkedIn",
             "twitter" to "Twitter",
-            "youtube" to "YouTube"
+            "youtube" to "YouTube",
+            "web" to "Website",
         )
         val socialLogoMap =
             mapOf(
@@ -26,7 +27,8 @@ data class Social(
                 "Facebook" to R.drawable.ic_facebook,
                 "LinkedIn" to R.drawable.ic_linkedin,
                 "Twitter" to R.drawable.ic_twitter,
-                "YouTube" to R.drawable.ic_youtube
+                "YouTube" to R.drawable.ic_youtube,
+                "Website" to R.drawable.ic_link,
             )
     }
 }

--- a/app/src/main/java/com/cornellappdev/android/volume/data/models/User.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/models/User.kt
@@ -5,10 +5,12 @@ package com.cornellappdev.android.volume.data.models
  *
  * @property uuid
  * @property followedPublicationSlugs
+ * @property followedOrganizationSlugs
  * @property weeklyDebrief
  */
 data class User(
     val uuid: String,
     val followedPublicationSlugs: List<String>,
-    val weeklyDebrief: WeeklyDebrief? = null
+    val followedOrganizationSlugs: List<String>,
+    val weeklyDebrief: WeeklyDebrief? = null,
 )

--- a/app/src/main/java/com/cornellappdev/android/volume/data/repositories/FlyerRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/repositories/FlyerRepository.kt
@@ -81,7 +81,10 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
                 categorySlug = flyerData.organization.categorySlug,
                 name = flyerData.organization.name,
                 slug = flyerData.organization.slug,
-                websiteURL = flyerData.organization.websiteURL
+                websiteURL = flyerData.organization.websiteURL,
+                backgroundImageURL = flyerData.organization.backgroundImageURL,
+                bio = flyerData.organization.bio,
+                profileImageURL = flyerData.organization.profileImageURL,
             ),
             location = flyerData.location,
             flyerURL = flyerData.flyerURL,
@@ -190,7 +193,8 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
         backgroundImageURL = this.backgroundImageURL,
         bio = this.bio,
         id = this.id,
-        slug = this.slug
+        slug = this.slug,
+        profileImageURL = this.profileImageURL,
     )
 
     private fun FlyersByIDsQuery.Organization.mapToOrganization(): Organization = Organization(
@@ -200,7 +204,8 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
         backgroundImageURL = this.backgroundImageURL,
         bio = this.bio,
         id = this.id,
-        slug = this.slug
+        slug = this.slug,
+        profileImageURL = this.profileImageURL,
     )
 
     private fun FlyersByCategorySlugQuery.Organization.mapToOrganization(): Organization =
@@ -211,7 +216,8 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
             backgroundImageURL = this.backgroundImageURL,
             bio = this.bio,
             id = this.id,
-            slug = this.slug
+            slug = this.slug,
+            profileImageURL = this.profileImageURL,
         )
 
     private fun TrendingFlyersQuery.Organization.mapToOrganization(): Organization = Organization(
@@ -221,7 +227,8 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
         backgroundImageURL = this.backgroundImageURL,
         bio = this.bio,
         id = this.id,
-        slug = this.slug
+        slug = this.slug,
+        profileImageURL = this.profileImageURL,
     )
 
     private fun FlyersAfterDateQuery.Organization.mapToOrganization(): Organization = Organization(
@@ -231,7 +238,8 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
         backgroundImageURL = this.backgroundImageURL,
         bio = this.bio,
         id = this.id,
-        slug = this.slug
+        slug = this.slug,
+        profileImageURL = this.profileImageURL,
     )
 
     private fun FlyersBeforeDateQuery.Organization.mapToOrganization(): Organization = Organization(
@@ -241,7 +249,8 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
         backgroundImageURL = this.backgroundImageURL,
         bio = this.bio,
         id = this.id,
-        slug = this.slug
+        slug = this.slug,
+        profileImageURL = this.profileImageURL,
     )
 
     private fun FlyersByOrganizationSlugQuery.Organization.mapToOrganization(): Organization =
@@ -252,7 +261,8 @@ class FlyerRepository @Inject constructor(private val networkApi: NetworkApi) {
             backgroundImageURL = this.backgroundImageURL,
             bio = this.bio,
             id = this.id,
-            slug = this.slug
+            slug = this.slug,
+            profileImageURL = this.profileImageURL,
         )
 }
 

--- a/app/src/main/java/com/cornellappdev/android/volume/data/repositories/OrganizationRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/repositories/OrganizationRepository.kt
@@ -35,4 +35,18 @@ class OrganizationRepository @Inject constructor(private val networkApi: Network
                 profileImageURL = it.profileImageURL,
             )
         }
+
+    suspend fun getAllOrganizations(): List<Organization> =
+        networkApi.fetchAllOrganizations().dataAssertNoErrors.getAllOrganizations.map {
+            Organization(
+                name = it.name,
+                categorySlug = it.categorySlug,
+                websiteURL = it.websiteURL,
+                backgroundImageURL = it.backgroundImageURL,
+                bio = it.bio,
+                id = it.id,
+                slug = it.slug,
+                profileImageURL = it.profileImageURL,
+            )
+        }
 }

--- a/app/src/main/java/com/cornellappdev/android/volume/data/repositories/OrganizationRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/repositories/OrganizationRepository.kt
@@ -17,7 +17,8 @@ class OrganizationRepository @Inject constructor(private val networkApi: Network
                 backgroundImageURL = it.backgroundImageURL,
                 bio = it.bio,
                 id = it.id,
-                slug = it.slug
+                slug = it.slug,
+                profileImageURL = it.profileImageURL
             )
         }
 
@@ -31,6 +32,7 @@ class OrganizationRepository @Inject constructor(private val networkApi: Network
                 bio = it.bio,
                 id = it.id,
                 slug = it.slug,
+                profileImageURL = it.profileImageURL,
             )
         }
 }

--- a/app/src/main/java/com/cornellappdev/android/volume/data/repositories/UserRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/repositories/UserRepository.kt
@@ -18,12 +18,13 @@ import javax.inject.Singleton
  * @see Article
  */
 private const val TAG = "UserRepository"
+
 @Singleton
 class UserRepository @Inject constructor(private val networkApi: NetworkApi) {
 
     suspend fun createUser(
         followPublications: List<String>,
-        deviceToken: String
+        deviceToken: String,
     ): User =
         networkApi.createUser(followPublications, deviceToken).dataAssertNoErrors.mapDataToUser()
 
@@ -32,13 +33,13 @@ class UserRepository @Inject constructor(private val networkApi: NetworkApi) {
             followPublication(it, uuid)
         }
 
-    suspend fun followPublication(slug: String, uuid: String): User  {
+    suspend fun followPublication(slug: String, uuid: String): User {
         return networkApi.followPublication(slug, uuid).dataAssertNoErrors.mapDataToUser()
     }
 
     suspend fun unfollowPublication(
         slug: String,
-        uuid: String
+        uuid: String,
     ): User =
         networkApi.unfollowPublication(slug, uuid).dataAssertNoErrors.mapDataToUser()
 
@@ -76,7 +77,8 @@ class UserRepository @Inject constructor(private val networkApi: NetworkApi) {
                         numBookmarkedArticles = weeklyDebrief.numBookmarkedArticles.toInt(),
                         numReadArticles = weeklyDebrief.numReadArticles.toInt()
                     )
-                }
+                },
+                followedOrganizationSlugs = TODO("Waiting on backend")
             )
         }
     }
@@ -87,7 +89,8 @@ class UserRepository @Inject constructor(private val networkApi: NetworkApi) {
                 uuid = userData.uuid,
                 followedPublicationSlugs = userData.followedPublications.map {
                     it.slug
-                }
+                },
+                followedOrganizationSlugs = TODO("Waiting on backend")
             )
         }
     }
@@ -95,10 +98,11 @@ class UserRepository @Inject constructor(private val networkApi: NetworkApi) {
     private fun FollowPublicationMutation.Data.mapDataToUser(): User {
         return this.followPublication.let { userData ->
             User(
-                uuid = userData?.uuid ?: "", // TODO figure out why user data is initially null
+                uuid = userData?.uuid ?: "",
                 followedPublicationSlugs = userData?.followedPublications?.map {
                     it.slug
-                } ?: listOf()
+                } ?: listOf(),
+                followedOrganizationSlugs = TODO("Waiting on backend")
             )
         }
     }
@@ -109,7 +113,8 @@ class UserRepository @Inject constructor(private val networkApi: NetworkApi) {
                 uuid = userData!!.uuid,
                 followedPublicationSlugs = userData.followedPublications.map {
                     it.slug
-                }
+                },
+                followedOrganizationSlugs = TODO("Waiting on backend")
             )
         }
     }

--- a/app/src/main/java/com/cornellappdev/android/volume/data/repositories/UserRepository.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/data/repositories/UserRepository.kt
@@ -1,8 +1,10 @@
 package com.cornellappdev.android.volume.data.repositories
 
 import com.cornellappdev.android.volume.CreateUserMutation
+import com.cornellappdev.android.volume.FollowOrganizationMutation
 import com.cornellappdev.android.volume.FollowPublicationMutation
 import com.cornellappdev.android.volume.GetUserQuery
+import com.cornellappdev.android.volume.UnfollowOrganizationMutation
 import com.cornellappdev.android.volume.UnfollowPublicationMutation
 import com.cornellappdev.android.volume.data.NetworkApi
 import com.cornellappdev.android.volume.data.models.Article
@@ -33,15 +35,23 @@ class UserRepository @Inject constructor(private val networkApi: NetworkApi) {
             followPublication(it, uuid)
         }
 
-    suspend fun followPublication(slug: String, uuid: String): User {
-        return networkApi.followPublication(slug, uuid).dataAssertNoErrors.mapDataToUser()
-    }
+    suspend fun followPublication(slug: String, uuid: String): User =
+        networkApi.followPublication(slug, uuid).dataAssertNoErrors.mapDataToUser()
+
+    suspend fun followOrganization(slug: String, uuid: String): User =
+        networkApi.followOrganization(slug, uuid).dataAssertNoErrors.mapDataToUser()
 
     suspend fun unfollowPublication(
         slug: String,
         uuid: String,
     ): User =
         networkApi.unfollowPublication(slug, uuid).dataAssertNoErrors.mapDataToUser()
+
+    suspend fun unfollowOrganization(
+        slug: String,
+        uuid: String,
+    ): User =
+        networkApi.unfollowOrganization(slug, uuid).dataAssertNoErrors.mapDataToUser()
 
     // Only getUser returns a User with WeeklyDebrief, can be updated in queries.graphql
     suspend fun getUser(uuid: String): User =
@@ -78,7 +88,7 @@ class UserRepository @Inject constructor(private val networkApi: NetworkApi) {
                         numReadArticles = weeklyDebrief.numReadArticles.toInt()
                     )
                 },
-                followedOrganizationSlugs = TODO("Waiting on backend")
+                followedOrganizationSlugs = userData.followedOrganizations.map { it.slug }
             )
         }
     }
@@ -90,7 +100,7 @@ class UserRepository @Inject constructor(private val networkApi: NetworkApi) {
                 followedPublicationSlugs = userData.followedPublications.map {
                     it.slug
                 },
-                followedOrganizationSlugs = TODO("Waiting on backend")
+                followedOrganizationSlugs = userData.followedOrganizations.map { it.slug }
             )
         }
     }
@@ -98,11 +108,23 @@ class UserRepository @Inject constructor(private val networkApi: NetworkApi) {
     private fun FollowPublicationMutation.Data.mapDataToUser(): User {
         return this.followPublication.let { userData ->
             User(
-                uuid = userData?.uuid ?: "",
-                followedPublicationSlugs = userData?.followedPublications?.map {
+                uuid = userData!!.uuid,
+                followedPublicationSlugs = userData.followedPublications.map {
                     it.slug
-                } ?: listOf(),
-                followedOrganizationSlugs = TODO("Waiting on backend")
+                },
+                followedOrganizationSlugs = userData.followedOrganizations.map { it.slug }
+            )
+        }
+    }
+
+    private fun FollowOrganizationMutation.Data.mapDataToUser(): User {
+        return this.followOrganization.let { userData ->
+            User(
+                uuid = userData!!.uuid,
+                followedPublicationSlugs = userData.followedPublications.map {
+                    it.slug
+                },
+                followedOrganizationSlugs = userData.followedOrganizations.map { it.slug }
             )
         }
     }
@@ -114,7 +136,19 @@ class UserRepository @Inject constructor(private val networkApi: NetworkApi) {
                 followedPublicationSlugs = userData.followedPublications.map {
                     it.slug
                 },
-                followedOrganizationSlugs = TODO("Waiting on backend")
+                followedOrganizationSlugs = userData.followedOrganizations.map { it.slug }
+            )
+        }
+    }
+
+    private fun UnfollowOrganizationMutation.Data.mapDataToUser(): User {
+        return this.unfollowOrganization.let { userData ->
+            User(
+                uuid = userData!!.uuid,
+                followedPublicationSlugs = userData.followedPublications.map {
+                    it.slug
+                },
+                followedOrganizationSlugs = userData.followedOrganizations.map { it.slug }
             )
         }
     }

--- a/app/src/main/java/com/cornellappdev/android/volume/navigation/MainTabbedNavigation.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/navigation/MainTabbedNavigation.kt
@@ -214,6 +214,12 @@ private fun MainScreenNavigationConfigurations(
                 navController.navigate("${Routes.OPEN_MAGAZINE.route}/${magazine.id}/${Routes.INDIVIDUAL_PUBLICATION.route}")
             })
         }
+
+        // This route should be navigated with a valid organization slug, else the screen will not
+        // populate.
+        composable("${Routes.INDIVIDUAL_ORGANIZATION.route}/{organizationSlug}") {
+            IndividualOrganizationScreen()
+        }
         // This route should be navigated with a valid article id.
         composable(
             route = "${Routes.OPEN_ARTICLE.route}/{articleId}/{navigationSourceName}",
@@ -283,6 +289,9 @@ private fun MainScreenNavigationConfigurations(
                 },
                 onSearchClick = {
                     navController.navigate("${Routes.SEARCH.route}/$it")
+                },
+                onOrganizationClick = {
+                    TODO()
                 }
             )
         }

--- a/app/src/main/java/com/cornellappdev/android/volume/navigation/MainTabbedNavigation.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/navigation/MainTabbedNavigation.kt
@@ -190,7 +190,10 @@ private fun MainScreenNavigationConfigurations(
                 navController.navigate("${Routes.OPEN_ARTICLE.route}/${article.id}/${navigationSource}")
             }, onMagazineClick = { magazine ->
                 navController.navigate("${Routes.OPEN_MAGAZINE.route}/${magazine.id}/${Routes.HOME.route}")
-            })
+            },
+                onOrganizationNameClick = { slug ->
+                    navController.navigate("${Routes.INDIVIDUAL_ORGANIZATION.route}/$slug")
+                })
         }
         composable(route = Routes.WEEKLY_DEBRIEF.route, deepLinks = listOf(
             navDeepLink { uriPattern = "volume://${Routes.WEEKLY_DEBRIEF.route}" }
@@ -283,15 +286,14 @@ private fun MainScreenNavigationConfigurations(
                     navController.navigate("${Routes.OPEN_ARTICLE.route}/${article.id}/${navigationSource.name}")
                 },
                 showBottomBar = showBottomBar,
-                onPublicationClick =
-                { publication ->
-                    navController.navigate("${Routes.INDIVIDUAL_PUBLICATION.route}/${publication.slug}")
+                onPublicationClick = { publicationSlug ->
+                    navController.navigate("${Routes.INDIVIDUAL_PUBLICATION.route}/$publicationSlug")
                 },
                 onSearchClick = {
                     navController.navigate("${Routes.SEARCH.route}/$it")
                 },
-                onOrganizationClick = {
-                    TODO()
+                onOrganizationClick = { organizationSlug ->
+                    "${Routes.INDIVIDUAL_ORGANIZATION.route}/$organizationSlug"
                 }
             )
         }
@@ -323,6 +325,8 @@ private fun MainScreenNavigationConfigurations(
         composable(Routes.FLYERS.route) {
             FlyersScreen(onSearchClick = {
                 navController.navigate("${Routes.SEARCH.route}/$it")
+            }, onOrganizationNameClick = { slug ->
+                navController.navigate("${Routes.INDIVIDUAL_ORGANIZATION.route}/$slug")
             })
         }
         composable(
@@ -346,6 +350,9 @@ private fun MainScreenNavigationConfigurations(
                 onSettingsClick = { navController.navigate(Routes.SETTINGS.route) },
                 onMagazineClick = { magazine ->
                     navController.navigate("${Routes.OPEN_MAGAZINE.route}/${magazine.id}/${Routes.BOOKMARKS.route}")
+                },
+                onOrganizationNameClick = { slug ->
+                    navController.navigate("${Routes.INDIVIDUAL_ORGANIZATION.route}/$slug")
                 })
         }
         composable(Routes.SETTINGS.route,
@@ -399,7 +406,11 @@ private fun MainScreenNavigationConfigurations(
                 navController.navigate("${Routes.OPEN_ARTICLE.route}/${article.id}/${navigationSource.name}")
             }, onMagazineClick = { magazine ->
                 navController.navigate("${Routes.OPEN_MAGAZINE.route}/${magazine.id}/${Routes.SEARCH.route}")
-            }, defaultTab = tabIndex ?: 0)
+            }, defaultTab = tabIndex ?: 0,
+                onOrganizationNameClick = { slug ->
+                    navController.navigate("${Routes.INDIVIDUAL_ORGANIZATION.route}/$slug")
+                }
+            )
         }
         composable(route = Routes.ORGANIZATION_LOGIN.route,
             enterTransition = {
@@ -424,6 +435,8 @@ private fun MainScreenNavigationConfigurations(
                     navController.navigate(
                         "${Routes.UPLOAD_FLYER.route}/$orgSlug/$flyerId"
                     )
+                }, onOrganizationNameClick = { slug ->
+                    navController.navigate("${Routes.INDIVIDUAL_ORGANIZATION.route}/$slug")
                 }
             )
         }

--- a/app/src/main/java/com/cornellappdev/android/volume/navigation/NavigationItem.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/navigation/NavigationItem.kt
@@ -92,4 +92,5 @@ enum class Routes(override var route: String) : NavUnit {
     UPLOAD_FLYER("upload_flyer"),
     FLYER_SUCCESS("flyer_success"),
     ORGANIZATION_HOME("organization_home"),
+    INDIVIDUAL_ORGANIZATION("organization"),
 }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/IndividualPartnerComponents.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/IndividualPartnerComponents.kt
@@ -1,6 +1,7 @@
 package com.cornellappdev.android.volume.ui.components.general
 
 import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -22,12 +23,15 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
@@ -58,32 +62,50 @@ fun CreateIndividualPartnerHeading(
     socials: List<Social>?,
     websiteURL: String,
 ) {
-    val hasBeenClicked = rememberSaveable { mutableStateOf(followButton) }
+    var hasBeenClicked by remember { mutableStateOf(followButton) }
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .wrapContentHeight()
     ) {
         Box {
-            AsyncImage(
-                model = backgroundImageUrl,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier
-                    .fillMaxWidth(),
-                contentDescription = null
-            )
-
-            AsyncImage(
-                model = profileImageURL,
-                contentScale = ContentScale.Crop,
-                alignment = Alignment.TopStart,
-                modifier = Modifier
-                    .padding(start = 8.dp, top = 130.dp)
-                    .size(64.dp)
-                    .clip(CircleShape)
-                    .shadow(4.dp, CircleShape),
-                contentDescription = null
-            )
+            if (backgroundImageUrl.isNullOrBlank()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color.Gray)
+                )
+            } else {
+                AsyncImage(
+                    model = backgroundImageUrl,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .fillMaxWidth(),
+                    contentDescription = null
+                )
+            }
+            if (profileImageURL.isNullOrBlank()) {
+                Box(
+                    modifier = Modifier
+                        .padding(start = 8.dp, top = 130.dp)
+                        .size(64.dp)
+                        .clip(CircleShape)
+                        .shadow(4.dp, CircleShape)
+                        .background(Color.Gray)
+                )
+            } else {
+                AsyncImage(
+                    model = profileImageURL,
+                    contentScale = ContentScale.Crop,
+                    alignment = Alignment.TopStart,
+                    modifier = Modifier
+                        .padding(start = 8.dp, top = 130.dp)
+                        .size(64.dp)
+                        .clip(CircleShape)
+                        .shadow(4.dp, CircleShape),
+                    contentDescription = null
+                )
+            }
         }
 
         Column(
@@ -111,13 +133,13 @@ fun CreateIndividualPartnerHeading(
                     modifier = Modifier
                         .height(33.dp),
                     onClick = {
-                        hasBeenClicked.value = !hasBeenClicked.value
-                        followButtonClicked(hasBeenClicked.value)
+                        hasBeenClicked = !hasBeenClicked
+                        followButtonClicked(hasBeenClicked)
                     },
                     shape = RoundedCornerShape(5.dp),
-                    colors = ButtonDefaults.buttonColors(backgroundColor = if (hasBeenClicked.value) VolumeOrange else GrayThree),
+                    colors = ButtonDefaults.buttonColors(backgroundColor = if (hasBeenClicked) VolumeOrange else GrayThree),
                 ) {
-                    Crossfade(targetState = hasBeenClicked.value, label = "") { hasBeenClicked ->
+                    Crossfade(targetState = hasBeenClicked, label = "") { hasBeenClicked ->
                         if (hasBeenClicked) {
                             Text(
                                 text = "Following",

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/IndividualPartnerComponents.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/IndividualPartnerComponents.kt
@@ -1,9 +1,17 @@
 package com.cornellappdev.android.volume.ui.components.general
 
 import androidx.compose.animation.Crossfade
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -13,7 +21,6 @@ import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -21,9 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -34,16 +39,24 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.cornellappdev.android.volume.R
-import com.cornellappdev.android.volume.data.models.Publication
-import com.cornellappdev.android.volume.data.models.Social.Companion.formattedSocialNameMap
-import com.cornellappdev.android.volume.data.models.Social.Companion.socialLogoMap
-import com.cornellappdev.android.volume.ui.theme.*
+import com.cornellappdev.android.volume.data.models.Social
+import com.cornellappdev.android.volume.ui.theme.GrayOne
+import com.cornellappdev.android.volume.ui.theme.GrayThree
+import com.cornellappdev.android.volume.ui.theme.VolumeOrange
+import com.cornellappdev.android.volume.ui.theme.lato
+import com.cornellappdev.android.volume.ui.theme.notoserif
 
 @Composable
-fun CreateIndividualPublicationHeading(
-    publication: Publication,
+fun CreateIndividualPartnerHeading(
     followButton: Boolean,
     followButtonClicked: (Boolean) -> Unit,
+    backgroundImageUrl: String?,
+    profileImageURL: String?,
+    partnerName: String,
+    statsText: String,
+    bio: String?,
+    socials: List<Social>?,
+    websiteURL: String,
 ) {
     val hasBeenClicked = rememberSaveable { mutableStateOf(followButton) }
     Column(
@@ -53,7 +66,7 @@ fun CreateIndividualPublicationHeading(
     ) {
         Box {
             AsyncImage(
-                model = publication.backgroundImageURL,
+                model = backgroundImageUrl,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
                     .fillMaxWidth(),
@@ -61,7 +74,7 @@ fun CreateIndividualPublicationHeading(
             )
 
             AsyncImage(
-                model = publication.profileImageURL,
+                model = profileImageURL,
                 contentScale = ContentScale.Crop,
                 alignment = Alignment.TopStart,
                 modifier = Modifier
@@ -86,7 +99,7 @@ fun CreateIndividualPublicationHeading(
                     modifier = Modifier
                         .weight(1f)
                         .padding(end = 20.dp),
-                    text = publication.name,
+                    text = partnerName,
                     maxLines = 3,
                     overflow = TextOverflow.Ellipsis,
                     fontFamily = notoserif,
@@ -104,7 +117,7 @@ fun CreateIndividualPublicationHeading(
                     shape = RoundedCornerShape(5.dp),
                     colors = ButtonDefaults.buttonColors(backgroundColor = if (hasBeenClicked.value) VolumeOrange else GrayThree),
                 ) {
-                    Crossfade(targetState = hasBeenClicked.value) { hasBeenClicked ->
+                    Crossfade(targetState = hasBeenClicked.value, label = "") { hasBeenClicked ->
                         if (hasBeenClicked) {
                             Text(
                                 text = "Following",
@@ -136,22 +149,23 @@ fun CreateIndividualPublicationHeading(
             }
 
             Text(
-                text = "${publication.numArticles.toInt()} articles · ${publication.shoutouts.toInt()} shoutouts",
+                text = statsText,
                 fontFamily = lato,
                 fontWeight = FontWeight.Medium,
                 fontSize = 10.sp,
                 color = GrayOne
             )
-
-            Text(
-                modifier = Modifier.padding(top = 2.dp),
-                text = publication.bio,
-                maxLines = 6,
-                overflow = TextOverflow.Ellipsis,
-                fontFamily = lato,
-                fontWeight = FontWeight.Medium,
-                fontSize = 14.sp
-            )
+            bio?.let {
+                Text(
+                    modifier = Modifier.padding(top = 2.dp),
+                    text = it,
+                    maxLines = 6,
+                    overflow = TextOverflow.Ellipsis,
+                    fontFamily = lato,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 14.sp
+                )
+            }
 
             Row(
                 modifier = Modifier
@@ -159,9 +173,9 @@ fun CreateIndividualPublicationHeading(
                     .horizontalScroll(rememberScrollState()),
                 horizontalArrangement = Arrangement.spacedBy(13.dp)
             ) {
-                for (social in publication.socials) {
+                socials?.forEach { social ->
                     val socialName =
-                        formattedSocialNameMap.getOrDefault(social.social, social.social)
+                        Social.formattedSocialNameMap.getOrDefault(social.social, social.social)
 
                     Row {
                         // Make sure that the drawable is in the socialLogoMap or the painter is null
@@ -169,18 +183,18 @@ fun CreateIndividualPublicationHeading(
                             displayText = socialName,
                             uri = social.url,
                             style = TextStyle(fontFamily = lato, color = VolumeOrange),
-                            painter = socialLogoMap[socialName]?.let { painterResource(it) },
+                            painter = Social.socialLogoMap[socialName]?.let { painterResource(it) },
                         )
                     }
                 }
 
-                val websiteURL =
-                    publication.websiteURL.removePrefix("https://").removePrefix("http://")
+                val formattedWebsiteURL =
+                    websiteURL.removePrefix("https://").removePrefix("http://")
                         .removePrefix("www.").removeSuffix("/")
 
                 HyperlinkText(
-                    displayText = websiteURL,
-                    uri = publication.websiteURL,
+                    displayText = formattedWebsiteURL,
+                    uri = websiteURL,
                     style = TextStyle(
                         fontFamily = lato,
                         color = VolumeOrange,
@@ -193,35 +207,3 @@ fun CreateIndividualPublicationHeading(
     }
 }
 
-@Composable
-fun HyperlinkText(
-    displayText: String,
-    uri: String,
-    style: TextStyle,
-    painter: Painter?
-) {
-    val uriHandler = LocalUriHandler.current
-
-    TextButton(
-        contentPadding = PaddingValues(0.dp),
-        onClick = {
-            uriHandler.openUri(uri)
-        }
-    ) {
-        if (painter != null) {
-            Image(
-                painter = painter,
-                contentDescription = "Icon",
-            )
-
-            Spacer(Modifier.size(ButtonDefaults.IconSpacing))
-        }
-
-        Text(
-            text = displayText,
-            maxLines = 1,
-            style = style,
-            overflow = TextOverflow.Ellipsis,
-        )
-    }
-}

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/PublicationComponents.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/PublicationComponents.kt
@@ -2,11 +2,28 @@ package com.cornellappdev.android.volume.ui.components.general
 
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.*
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Done
@@ -24,22 +41,31 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
-import com.cornellappdev.android.volume.data.models.Publication
-import com.cornellappdev.android.volume.ui.theme.*
+import com.cornellappdev.android.volume.ui.theme.GrayFour
+import com.cornellappdev.android.volume.ui.theme.GrayOne
+import com.cornellappdev.android.volume.ui.theme.VolumeOrange
+import com.cornellappdev.android.volume.ui.theme.lato
+import com.cornellappdev.android.volume.ui.theme.notoserif
 
 /**
- * Creates a Horizontal Publication Row for the Publication passed in.
+ * Creates a Horizontal Partner Row for the Partner passed in.
  *
- * The callback returns the publication back when the follow button is
- * clicked, and returns true when the publication is followed.
+ * The callback returns the partner back when the follow button is
+ * clicked, and returns true when the partner is followed.
  *
  * @param publication
  * @param followButtonClicked
  */
 @Composable
-fun CreatePublicationRow(
-    publication: Publication,
-    followButtonClicked: (Publication, Boolean) -> Unit,
+fun CreatePartnerRow(
+    profileImageURL: String?,
+    name: String,
+    slug: String,
+    bio: String?,
+    mostRecentArticleTitle: String? = null,
+    onPartnerClick: (slug: String) -> Unit,
+    isFollowed: Boolean,
+    followButtonClicked: (partnerSlug: String, Boolean) -> Unit,
 ) {
     val hasBeenClicked = rememberSaveable { mutableStateOf(false) }
     Row(
@@ -48,12 +74,14 @@ fun CreatePublicationRow(
             .fillMaxWidth(),
     ) {
         AsyncImage(
-            model = publication.profileImageURL,
+            model = profileImageURL,
             contentScale = ContentScale.Crop,
             modifier = Modifier
                 .padding(end = 8.dp)
                 .size(64.dp)
-                .clip(CircleShape),
+                .clip(CircleShape)
+                .background(Color.Gray)
+                .clickable { onPartnerClick(slug) },
             contentDescription = null
         )
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -63,8 +91,9 @@ fun CreatePublicationRow(
                 Text(
                     modifier = Modifier
                         .padding(end = 20.dp)
-                        .weight(1f),
-                    text = publication.name,
+                        .weight(1f)
+                        .clickable { onPartnerClick(slug) },
+                    text = name,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     fontFamily = notoserif,
@@ -77,14 +106,14 @@ fun CreatePublicationRow(
                     // Passes true to callback if followed, false if unfollowed.
                     onClick = {
                         hasBeenClicked.value = !hasBeenClicked.value
-                        followButtonClicked(publication, hasBeenClicked.value)
+                        followButtonClicked(slug, isFollowed)
                     },
                     shape = RoundedCornerShape(12.dp),
                     contentPadding = PaddingValues(0.dp),
                     colors = ButtonDefaults.buttonColors(backgroundColor = if (hasBeenClicked.value) VolumeOrange else Color.White),
                     border = if (hasBeenClicked.value) null else BorderStroke(2.dp, Color.Black)
                 ) {
-                    Crossfade(targetState = hasBeenClicked.value) { hasBeenClicked ->
+                    Crossfade(targetState = hasBeenClicked.value, label = "") { hasBeenClicked ->
                         if (hasBeenClicked) {
                             Icon(
                                 Icons.Default.Done,
@@ -102,152 +131,29 @@ fun CreatePublicationRow(
                 }
 
             }
-
-            Row(
-                horizontalArrangement = Arrangement.SpaceBetween,
-                modifier = Modifier
-                    .height(IntrinsicSize.Min)
-                    .padding(bottom = 2.dp)
-            ) {
-
-                Text(
-                    modifier = Modifier.padding(end = 20.dp),
-                    text = publication.bio,
-                    color = GrayOne,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                    fontFamily = lato,
-                    fontWeight = FontWeight.SemiBold,
-                    fontSize = 12.sp
-                )
-
-                Spacer(modifier = Modifier.fillMaxHeight())
-            }
-
-            publication.mostRecentArticle?.let {
+            if (!bio.isNullOrBlank()) {
                 Row(
                     horizontalArrangement = Arrangement.SpaceBetween,
-                    modifier = Modifier.height(IntrinsicSize.Min)
-                ) {
-                    Row(modifier = Modifier.height(IntrinsicSize.Min)) {
-                        Divider(
-                            color = GrayFour,
-                            modifier = Modifier
-                                .fillMaxHeight()
-                                .width(1.dp)
-                        )
-
-                        Text(
-                            modifier = Modifier.padding(start = 8.dp, end = 20.dp),
-                            text = "\"${it.title}\"",
-                            color = Color.Black,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            fontFamily = lato,
-                            fontWeight = FontWeight.Medium,
-                            fontSize = 12.sp
-                        )
-                    }
-
-                    Spacer(modifier = Modifier.fillMaxHeight())
-                }
-            }
-        }
-    }
-}
-
-@Composable
-fun CreatePublicationRow(
-    publication: Publication,
-    onPublicationClick: (Publication) -> Unit,
-    followButtonClicked: (Publication, Boolean) -> Unit
-) {
-
-    var hasBeenClicked = false
-    Row(
-        modifier = Modifier
-            .height(100.dp)
-            .fillMaxWidth()
-            .clickable {
-                onPublicationClick(publication)
-            },
-    ) {
-        AsyncImage(
-            model = publication.profileImageURL,
-            contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .padding(end = 8.dp)
-                .size(64.dp)
-                .clip(CircleShape),
-            contentDescription = null
-        )
-        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Row(
-                modifier = Modifier.height(IntrinsicSize.Min)
-            ) {
-                Text(
                     modifier = Modifier
-                        .padding(end = 20.dp)
-                        .weight(1f),
-                    text = publication.name,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    fontFamily = notoserif,
-                    fontWeight = FontWeight.Medium,
-                    fontSize = 18.sp
-                )
-
-                OutlinedButton(
-                    modifier = Modifier.size(33.dp),
-                    // Passes true to callback if followed, false if unfollowed.
-                    onClick = {
-                        hasBeenClicked = !hasBeenClicked
-                        followButtonClicked(publication, hasBeenClicked)
-                    },
-                    shape = RoundedCornerShape(12.dp),
-                    contentPadding = PaddingValues(0.dp),
-                    colors = ButtonDefaults.buttonColors(backgroundColor = if (hasBeenClicked) VolumeOrange else Color.White),
-                    border = if (hasBeenClicked) null else BorderStroke(2.dp, Color.Black)
+                        .height(IntrinsicSize.Min)
+                        .padding(bottom = 2.dp)
                 ) {
-                    Crossfade(targetState = hasBeenClicked) { hasBeenClicked ->
-                        if (hasBeenClicked) {
-                            Icon(
-                                Icons.Default.Done,
-                                contentDescription = "Followed",
-                                tint = Color.White
-                            )
-                        } else {
-                            Icon(
-                                Icons.Default.Add,
-                                contentDescription = "Follow",
-                                tint = Color.Black
-                            )
-                        }
-                    }
+
+                    Text(
+                        modifier = Modifier.padding(end = 20.dp),
+                        text = bio,
+                        color = GrayOne,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        fontFamily = lato,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 12.sp
+                    )
+
+                    Spacer(modifier = Modifier.fillMaxHeight())
                 }
             }
-
-            Row(
-                horizontalArrangement = Arrangement.SpaceBetween,
-                modifier = Modifier
-                    .height(IntrinsicSize.Min)
-                    .padding(bottom = 2.dp)
-            ) {
-                Text(
-                    modifier = Modifier.padding(end = 20.dp),
-                    text = publication.bio,
-                    color = GrayOne,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                    fontFamily = lato,
-                    fontWeight = FontWeight.SemiBold,
-                    fontSize = 12.sp
-                )
-
-                Spacer(modifier = Modifier.fillMaxHeight())
-            }
-
-            publication.mostRecentArticle?.let {
+            mostRecentArticleTitle?.let {
                 Row(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     modifier = Modifier.height(IntrinsicSize.Min)
@@ -262,7 +168,7 @@ fun CreatePublicationRow(
 
                         Text(
                             modifier = Modifier.padding(start = 8.dp, end = 20.dp),
-                            text = "\"${it.title}\"",
+                            text = "\"$it\"",
                             color = Color.Black,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
@@ -280,36 +186,37 @@ fun CreatePublicationRow(
 }
 
 @Composable
-fun CreatePublicationColumn(
-    publication: Publication,
-    onPublicationClick: (Publication) -> Unit
+fun CreatePartnerColumn(
+    profileImageURL: String?,
+    slug: String,
+    title: String,
+    onPartnerClick: (slug: String) -> Unit,
 ) {
-    val title = publication.name
-
     Column(
         modifier = Modifier
             .wrapContentHeight()
             .width(100.dp)
             .clickable {
-                onPublicationClick(publication)
+                onPartnerClick(slug)
             },
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         AsyncImage(
-            model = publication.profileImageURL, modifier = Modifier
+            model = profileImageURL, modifier = Modifier
                 .height(100.dp)
                 .width(100.dp)
-                .clip(CircleShape), contentDescription = null, contentScale = ContentScale.Crop
+                .clip(CircleShape)
+                .background(Color.Gray), contentDescription = null, contentScale = ContentScale.Crop
         )
         Text(
             modifier = Modifier.padding(bottom = 2.dp, top = 2.dp),
             text = title,
-            maxLines = 3,
+            maxLines = 2,
             overflow = TextOverflow.Ellipsis,
             fontFamily = notoserif,
             fontWeight = FontWeight.Medium,
             fontSize = 12.sp,
-            textAlign = TextAlign.Center
+            textAlign = TextAlign.Center,
         )
     }
 }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/VolumeGeneralComponents.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/general/VolumeGeneralComponents.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -27,6 +28,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.Text
@@ -34,6 +36,7 @@ import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Warning
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -50,13 +53,16 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -456,3 +462,36 @@ fun Int.toComposeColor(): Color {
     return Color(red, green, blue, alpha)
 }
 
+
+@Composable
+fun HyperlinkText(
+    displayText: String,
+    uri: String,
+    style: TextStyle,
+    painter: Painter?,
+) {
+    val uriHandler = LocalUriHandler.current
+
+    TextButton(
+        contentPadding = PaddingValues(0.dp),
+        onClick = {
+            uriHandler.openUri(uri)
+        }
+    ) {
+        if (painter != null) {
+            Image(
+                painter = painter,
+                contentDescription = "Icon",
+            )
+
+            Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+        }
+
+        Text(
+            text = displayText,
+            maxLines = 1,
+            style = style,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/components/onboarding/SecondPage.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/components/onboarding/SecondPage.kt
@@ -1,5 +1,6 @@
 package com.cornellappdev.android.volume.ui.components.onboarding
 
+import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
@@ -52,7 +53,7 @@ import com.cornellappdev.android.volume.R
 import com.cornellappdev.android.volume.analytics.EventType
 import com.cornellappdev.android.volume.analytics.NavigationSource
 import com.cornellappdev.android.volume.analytics.VolumeEvent
-import com.cornellappdev.android.volume.ui.components.general.CreatePublicationRow
+import com.cornellappdev.android.volume.ui.components.general.CreatePartnerRow
 import com.cornellappdev.android.volume.ui.components.general.ErrorState
 import com.cornellappdev.android.volume.ui.states.PublicationsRetrievalState
 import com.cornellappdev.android.volume.ui.theme.GrayOne
@@ -154,26 +155,35 @@ fun SecondPage(
                             ) { publication ->
                                 // Clicking on row IN onboarding should not lead to IndividualPublicationScreen. They are not
                                 // an official user yet so they shouldn't be interacting with the articles.
-                                CreatePublicationRow(publication = publication) { publicationFromCallback, isFollowing ->
-                                    if (isFollowing) {
-                                        onboardingViewModel.addPublicationToFollowed(
-                                            publicationFromCallback.slug
-                                        )
-                                        VolumeEvent.logEvent(
-                                            EventType.PUBLICATION,
-                                            VolumeEvent.FOLLOW_PUBLICATION,
-                                            NavigationSource.ONBOARDING,
-                                            publicationFromCallback.slug
-                                        )
-                                    } else {
+                                CreatePartnerRow(
+                                    bio = publication.bio,
+                                    profileImageURL = publication.profileImageURL,
+                                    name = publication.name,
+                                    slug = publication.slug,
+                                    mostRecentArticleTitle = publication.mostRecentArticle?.title,
+                                    onPartnerClick = {},
+                                    isFollowed = false
+                                ) { slugFromCallback, notFollowing ->
+                                    if (notFollowing) {
                                         onboardingViewModel.removePublicationFromFollowed(
-                                            publicationFromCallback.slug
+                                            slugFromCallback
                                         )
                                         VolumeEvent.logEvent(
                                             EventType.PUBLICATION,
                                             VolumeEvent.UNFOLLOW_PUBLICATION,
                                             NavigationSource.ONBOARDING,
-                                            publicationFromCallback.slug
+                                            slugFromCallback
+                                        )
+                                    } else {
+                                        onboardingViewModel.addPublicationToFollowed(
+                                            slugFromCallback
+                                        )
+
+                                        VolumeEvent.logEvent(
+                                            EventType.PUBLICATION,
+                                            VolumeEvent.FOLLOW_PUBLICATION,
+                                            NavigationSource.ONBOARDING,
+                                            slugFromCallback
                                         )
                                     }
 

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/BookmarkScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/BookmarkScreen.kt
@@ -72,6 +72,7 @@ fun BookmarkScreen(
     onArticleClick: (Article, NavigationSource) -> Unit,
     onMagazineClick: (Magazine) -> Unit,
     onSettingsClick: () -> Unit,
+    onOrganizationNameClick: (slug: String) -> Unit,
 ) {
     val bookmarkUiState = bookmarkViewModel.bookmarkUiState
 
@@ -89,11 +90,12 @@ fun BookmarkScreen(
         BookmarksTopBar(onSettingsClick)
     }, content = { innerPadding ->
         Box(modifier = Modifier.padding(innerPadding)) {
-            TabbedBooksmarksView(
+            TabbedBookmarksView(
                 onArticleClick = onArticleClick,
                 onMagazineClick = onMagazineClick,
                 bookmarkUiState = bookmarkUiState,
                 bookmarkViewModel = bookmarkViewModel,
+                onOrganizationNameClick = onOrganizationNameClick
             )
         }
     })
@@ -101,11 +103,12 @@ fun BookmarkScreen(
 
 @RequiresApi(Build.VERSION_CODES.P)
 @Composable
-fun TabbedBooksmarksView(
+fun TabbedBookmarksView(
     onArticleClick: (Article, NavigationSource) -> Unit,
     bookmarkUiState: BookmarkViewModel.BookmarkUiState,
     bookmarkViewModel: BookmarkViewModel,
     onMagazineClick: (Magazine) -> Unit,
+    onOrganizationNameClick: (slug: String) -> Unit,
 ) {
     var tabIndex by remember { mutableStateOf(0) };
 
@@ -126,7 +129,8 @@ fun TabbedBooksmarksView(
         when (tabIndex) {
             0 -> BookmarkedFlyersView(
                 bookmarkUiState = bookmarkUiState,
-                bookmarkViewModel = bookmarkViewModel
+                bookmarkViewModel = bookmarkViewModel,
+                onOrganizationNameClick = onOrganizationNameClick,
             )
 
             1 -> BookmarkedArticlesView(
@@ -147,6 +151,7 @@ fun TabbedBooksmarksView(
 fun BookmarkedFlyersView(
     bookmarkUiState: BookmarkViewModel.BookmarkUiState,
     bookmarkViewModel: BookmarkViewModel,
+    onOrganizationNameClick: (slug: String) -> Unit,
 ) {
     var upcomingSelectedIndex by remember { mutableStateOf(0) }
     var upcomingExpanded by remember { mutableStateOf(false) }
@@ -289,7 +294,11 @@ fun BookmarkedFlyersView(
                             modifier = Modifier.height(308.dp)
                         ) {
                             items(upcomingState.flyers) {
-                                SmallFlyer(isExtraSmall = true, flyer = it)
+                                SmallFlyer(
+                                    isExtraSmall = true,
+                                    flyer = it,
+                                    onOrganizationNameClick = onOrganizationNameClick
+                                )
                             }
                         }
                     }
@@ -420,7 +429,12 @@ fun BookmarkedFlyersView(
                         )
                     }
                     items(pastState.flyers) {
-                        SmallFlyer(isExtraSmall = false, flyer = it, showTag = false)
+                        SmallFlyer(
+                            isExtraSmall = false,
+                            flyer = it,
+                            showTag = false,
+                            onOrganizationNameClick = onOrganizationNameClick
+                        )
                         Spacer(
                             modifier = Modifier
                                 .height(16.dp)

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/FlyersScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/FlyersScreen.kt
@@ -16,20 +16,28 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -47,7 +55,9 @@ import com.cornellappdev.android.volume.ui.states.FlyersRetrievalState
 import com.cornellappdev.android.volume.ui.theme.VolumeOrange
 import com.cornellappdev.android.volume.ui.theme.notoserif
 import com.cornellappdev.android.volume.ui.viewmodels.FlyersViewModel
+import com.cornellappdev.android.volume.ui.viewmodels.OrganizationsViewModel
 import com.cornellappdev.android.volume.util.FlyerConstants
+import kotlinx.coroutines.launch
 
 private const val NO_FLYERS_MESSAGE =
     "If you want to see your organization's events on Volume, email us at volumeappdev@gmail.com"
@@ -55,9 +65,13 @@ private const val NO_FLYERS_MESSAGE =
 @Composable
 fun FlyersScreen(
     flyersViewModel: FlyersViewModel = hiltViewModel(),
+    organizationsViewModel: OrganizationsViewModel = hiltViewModel(),
     onSearchClick: (Int) -> Unit,
+    onOrganizationNameClick: (slug: String) -> Unit,
 ) {
     var selectedIndex by remember { mutableStateOf(0) }
+    val scaffoldState = rememberScaffoldState()
+    val coroutineScope = rememberCoroutineScope()
     val tags = FlyerConstants.CATEGORY_SLUGS.split(",")
     // Maps the category slugs to strings that are viewable on the app.
     val formattedTags = tags.map { s ->
@@ -73,286 +87,360 @@ fun FlyersScreen(
     var expanded by remember { mutableStateOf(false) }
     val uiState = flyersViewModel.flyersUiState
 
+    val drawerClosed = scaffoldState.drawerState.isOpen
+    LaunchedEffect(key1 = drawerClosed, block = {
+        organizationsViewModel.reload()
+    })
 
-    LazyColumn(modifier = Modifier.padding(start = 16.dp)) {
-        // Page title
-        item {
-            Row {
-                Text(
-                    text = "Flyers",
-                    fontFamily = notoserif,
-                    fontSize = 28.sp,
-                    fontWeight = FontWeight.Medium,
-                    modifier = Modifier.padding(top = 16.dp)
-                )
-                VolumePeriod(modifier = Modifier.padding(top = 39.dp, start = 7.dp))
-            }
-        }
-        // Search bar
-        item {
-            Box(modifier = Modifier.padding(end = 16.dp, top = 16.dp)) {
-                SearchBar(
-                    value = "",
-                    onValueChange = {},
-                    onClick = { onSearchClick(2) },
-                )
-            }
-        }
-        // Today header
-        item {
-            Spacer(
-                modifier = Modifier
-                    .height(16.dp)
-                    .fillMaxWidth()
-            )
-            VolumeHeaderText(text = "Today", underline = R.drawable.ic_today_underline)
-            Spacer(
-                modifier = Modifier
-                    .height(8.dp)
-                    .fillMaxWidth()
-            )
-        }
-
-        // Big flyer row
-        item {
-            when (val todayFlyersState = uiState.todayFlyersState) {
-                FlyersRetrievalState.Loading -> {
-                    LazyRow(content = {
-                        items(5) {
-                            BigShimmeringFlyer(imgWidth = 340, imgHeight = 340)
-                            Spacer(modifier = Modifier.width(16.dp))
-                        }
-                    })
+    CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+        Scaffold(
+            scaffoldState = scaffoldState,
+            drawerContent = {
+                CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                    OrganizationsMenu(onOrganizationSlugClick = onOrganizationNameClick)
                 }
-
-                FlyersRetrievalState.Error -> {
-                    ErrorState()
-                }
-
-                is FlyersRetrievalState.Success -> {
-                    val flyers = todayFlyersState.flyers
-                    if (flyers.isEmpty()) {
-                        NothingToShowMessage(title = "No flyers today", message = NO_FLYERS_MESSAGE)
-                    } else {
-                        LazyRow {
-                            items(flyers) {
-                                BigFlyer(340.dp, it)
-                                Spacer(modifier = Modifier.width(16.dp))
+            },
+            content = { innerPadding ->
+                CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                    LazyColumn(
+                        modifier = Modifier.padding(
+                            start = 16.dp,
+                            top = innerPadding.calculateTopPadding()
+                        )
+                    ) {
+                        // Page title
+                        item {
+                            Row {
+                                Text(
+                                    text = "Flyers",
+                                    fontFamily = notoserif,
+                                    fontSize = 28.sp,
+                                    fontWeight = FontWeight.Medium,
+                                    modifier = Modifier.padding(top = 16.dp)
+                                )
+                                VolumePeriod(modifier = Modifier.padding(top = 39.dp, start = 7.dp))
                             }
                         }
-                    }
-                }
-            }
-        }
-
-
-        // This week header
-        item {
-            Spacer(
-                modifier = Modifier
-                    .height(32.dp)
-                    .fillMaxWidth()
-            )
-            VolumeHeaderText(text = "This Week", underline = R.drawable.ic_underline_this_week)
-            Spacer(
-                modifier = Modifier
-                    .height(8.dp)
-                    .fillMaxWidth()
-            )
-        }
-
-        // Big flyer row
-        item {
-            when (val weeklyFlyersState = uiState.weeklyFlyersState) {
-                FlyersRetrievalState.Loading -> {
-                    LazyRow {
-                        items(5) {
-                            BigShimmeringFlyer(imgWidth = 256, imgHeight = 256)
-                            Spacer(modifier = Modifier.width(16.dp))
-                        }
-                    }
-                }
-
-                FlyersRetrievalState.Error -> {
-                    ErrorState()
-                }
-
-                is FlyersRetrievalState.Success -> {
-                    val flyers = weeklyFlyersState.flyers
-                    if (flyers.isEmpty()) {
-                        NothingToShowMessage(
-                            title = "No flyers this week",
-                            message = NO_FLYERS_MESSAGE
-                        )
-                    } else {
-                        LazyRow {
-                            items(flyers) {
-                                BigFlyer(256.dp, it)
-                                Spacer(modifier = Modifier.width(16.dp))
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Upcoming and dropdown menu
-        item {
-            Spacer(modifier = Modifier.height(40.dp))
-
-            Row {
-                VolumeHeaderText(text = "Upcoming", underline = R.drawable.ic_underline_upcoming)
-
-                Spacer(modifier = Modifier.weight(1F))
-
-                // Dropdown menu
-                Column(modifier = Modifier.padding(end = 24.dp /* this is 16 because offset */)) {
-                    Box(modifier = Modifier.drawWithContent {
-                        drawContent()
-                        drawRoundRect(
-                            color = VolumeOrange,
-                            style = Stroke(width = 1.5.dp.toPx()),
-                            cornerRadius = CornerRadius(
-                                x = 5.dp.toPx(),
-                                y = 5.dp.toPx()
-                            ),
-                            size = Size(
-                                width = 128.dp.toPx(),
-                                height = 31.dp.toPx()
-                            ),
-                            topLeft = Offset(x = 8.dp.toPx(), y = 0.dp.toPx())
-                        )
-                    }) {
-                        Row {
-                            Text(
-                                text = formattedTags[selectedIndex],
-                                color = VolumeOrange,
+                        // Search bar
+                        item {
+                            Row(
                                 modifier = Modifier
-                                    .clickable {
-                                        expanded = true
-                                    }
-                                    .padding(horizontal = 16.dp, vertical = 8.dp)
-                                    .height(16.dp)
-                                    .defaultMinSize(minWidth = 82.dp),
-                                fontSize = 12.sp,
-                                fontWeight = FontWeight.Medium,
-                            )
-                            Image(
-                                painter = painterResource(id = R.drawable.ic_dropdown),
-                                contentDescription = null,
-                                modifier = Modifier
-                                    .padding(top = 12.dp)
-                                    .clickable {
-                                        expanded = true
-                                    }
-                            )
-                        }
-                    }
-
-                    DropdownMenu(
-                        expanded = expanded,
-                        onDismissRequest = { expanded = false }) {
-                        formattedTags.forEachIndexed { index, s ->
-                            if (index != selectedIndex) {
-                                DropdownMenuItem(onClick = {
-                                    selectedIndex = index
-                                    expanded = false
-                                    flyersViewModel.queryUpcomingFlyers(tags[selectedIndex])
-                                }) {
-                                    Text(
-                                        text = s,
-                                        color = VolumeOrange,
-                                        fontWeight = FontWeight.Medium,
-                                        fontSize = 12.sp,
+                                    .padding(end = 16.dp, top = 16.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Box(modifier = Modifier.weight(6F)) {
+                                    SearchBar(
+                                        value = "",
+                                        onValueChange = {},
+                                        onClick = { onSearchClick(2) },
+                                        modifier = Modifier.padding(end = 16.dp)
                                     )
+                                }
+                                Image(painter = painterResource(id = R.drawable.ic_hamburger),
+                                    contentDescription = null,
+                                    modifier = Modifier
+                                        .clickable {
+                                            coroutineScope.launch {
+                                                scaffoldState.drawerState.open()
+                                            }
+                                        }
+                                        .weight(1F)
+                                )
+                            }
+
+                        }
+                        // Today header
+                        item {
+                            Spacer(
+                                modifier = Modifier
+                                    .height(16.dp)
+                                    .fillMaxWidth()
+                            )
+                            VolumeHeaderText(
+                                text = "Today",
+                                underline = R.drawable.ic_today_underline
+                            )
+                            Spacer(
+                                modifier = Modifier
+                                    .height(8.dp)
+                                    .fillMaxWidth()
+                            )
+                        }
+
+                        // Big flyer row
+                        item {
+                            when (val todayFlyersState = uiState.todayFlyersState) {
+                                FlyersRetrievalState.Loading -> {
+                                    LazyRow(content = {
+                                        items(5) {
+                                            BigShimmeringFlyer(imgWidth = 340, imgHeight = 340)
+                                            Spacer(modifier = Modifier.width(16.dp))
+                                        }
+                                    })
+                                }
+
+                                FlyersRetrievalState.Error -> {
+                                    ErrorState()
+                                }
+
+                                is FlyersRetrievalState.Success -> {
+                                    val flyers = todayFlyersState.flyers
+                                    if (flyers.isEmpty()) {
+                                        NothingToShowMessage(
+                                            title = "No flyers today",
+                                            message = NO_FLYERS_MESSAGE
+                                        )
+                                    } else {
+                                        LazyRow {
+                                            items(flyers) {
+                                                BigFlyer(
+                                                    340.dp,
+                                                    it,
+                                                    onOrganizationNameClick = onOrganizationNameClick
+                                                )
+                                                Spacer(modifier = Modifier.width(16.dp))
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
-                    }
-                }
-            }
-            Spacer(modifier = Modifier.height(8.dp))
-        }
-        // Upcoming flyer display
-        when (val upcomingFlyerState = uiState.upcomingFlyersState) {
-            FlyersRetrievalState.Loading -> {
-                items(5) {
-                    ShimmeringFlyer()
-                    Spacer(modifier = Modifier.height(16.dp))
-                }
-            }
 
-            FlyersRetrievalState.Error -> {
-                item {
-                    ErrorState()
-                }
-            }
 
-            is FlyersRetrievalState.Success -> {
-                val flyers = upcomingFlyerState.flyers
-                if (flyers.isEmpty()) {
-                    item {
-                        NothingToShowMessage(
-                            title = "No upcoming flyers",
-                            message = "If you want to see your organization’s events on Volume, email us at volumeappdev@gmail.com"
-                        )
-                    }
-                } else {
-                    items(flyers) {
-                        Box(modifier = Modifier.padding(end = 16.dp)) {
-                            SmallFlyer(isExtraSmall = false, it)
+                        // This week header
+                        item {
+                            Spacer(
+                                modifier = Modifier
+                                    .height(32.dp)
+                                    .fillMaxWidth()
+                            )
+                            VolumeHeaderText(
+                                text = "This Week",
+                                underline = R.drawable.ic_underline_this_week
+                            )
+                            Spacer(
+                                modifier = Modifier
+                                    .height(8.dp)
+                                    .fillMaxWidth()
+                            )
+                        }
+
+                        // Big flyer row
+                        item {
+                            when (val weeklyFlyersState = uiState.weeklyFlyersState) {
+                                FlyersRetrievalState.Loading -> {
+                                    LazyRow {
+                                        items(5) {
+                                            BigShimmeringFlyer(imgWidth = 256, imgHeight = 256)
+                                            Spacer(modifier = Modifier.width(16.dp))
+                                        }
+                                    }
+                                }
+
+                                FlyersRetrievalState.Error -> {
+                                    ErrorState()
+                                }
+
+                                is FlyersRetrievalState.Success -> {
+                                    val flyers = weeklyFlyersState.flyers
+                                    if (flyers.isEmpty()) {
+                                        NothingToShowMessage(
+                                            title = "No flyers this week",
+                                            message = NO_FLYERS_MESSAGE
+                                        )
+                                    } else {
+                                        LazyRow {
+                                            items(flyers) {
+                                                BigFlyer(
+                                                    256.dp,
+                                                    it,
+                                                    onOrganizationNameClick = onOrganizationNameClick
+                                                )
+                                                Spacer(modifier = Modifier.width(16.dp))
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        // Upcoming and dropdown menu
+                        item {
+                            Spacer(modifier = Modifier.height(40.dp))
+
+                            Row {
+                                VolumeHeaderText(
+                                    text = "Upcoming",
+                                    underline = R.drawable.ic_underline_upcoming
+                                )
+
+                                Spacer(modifier = Modifier.weight(1F))
+
+                                // Dropdown menu
+                                Column(modifier = Modifier.padding(end = 24.dp /* this is 16 because offset */)) {
+                                    Box(modifier = Modifier.drawWithContent {
+                                        drawContent()
+                                        drawRoundRect(
+                                            color = VolumeOrange,
+                                            style = Stroke(width = 1.5.dp.toPx()),
+                                            cornerRadius = CornerRadius(
+                                                x = 5.dp.toPx(),
+                                                y = 5.dp.toPx()
+                                            ),
+                                            size = Size(
+                                                width = 128.dp.toPx(),
+                                                height = 31.dp.toPx()
+                                            ),
+                                            topLeft = Offset(x = 8.dp.toPx(), y = 0.dp.toPx())
+                                        )
+                                    }) {
+                                        Row {
+                                            Text(
+                                                text = formattedTags[selectedIndex],
+                                                color = VolumeOrange,
+                                                modifier = Modifier
+                                                    .clickable {
+                                                        expanded = true
+                                                    }
+                                                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                                                    .height(16.dp)
+                                                    .defaultMinSize(minWidth = 82.dp),
+                                                fontSize = 12.sp,
+                                                fontWeight = FontWeight.Medium,
+                                            )
+                                            Image(
+                                                painter = painterResource(id = R.drawable.ic_dropdown),
+                                                contentDescription = null,
+                                                modifier = Modifier
+                                                    .padding(top = 12.dp)
+                                                    .clickable {
+                                                        expanded = true
+                                                    }
+                                            )
+                                        }
+                                    }
+
+                                    DropdownMenu(
+                                        expanded = expanded,
+                                        onDismissRequest = { expanded = false }) {
+                                        formattedTags.forEachIndexed { index, s ->
+                                            if (index != selectedIndex) {
+                                                DropdownMenuItem(onClick = {
+                                                    selectedIndex = index
+                                                    expanded = false
+                                                    flyersViewModel.queryUpcomingFlyers(tags[selectedIndex])
+                                                }) {
+                                                    Text(
+                                                        text = s,
+                                                        color = VolumeOrange,
+                                                        fontWeight = FontWeight.Medium,
+                                                        fontSize = 12.sp,
+                                                    )
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            Spacer(modifier = Modifier.height(8.dp))
+                        }
+                        // Upcoming flyer display
+                        when (val upcomingFlyerState = uiState.upcomingFlyersState) {
+                            FlyersRetrievalState.Loading -> {
+                                items(5) {
+                                    ShimmeringFlyer()
+                                    Spacer(modifier = Modifier.height(16.dp))
+                                }
+                            }
+
+                            FlyersRetrievalState.Error -> {
+                                item {
+                                    ErrorState()
+                                }
+                            }
+
+                            is FlyersRetrievalState.Success -> {
+                                val flyers = upcomingFlyerState.flyers
+                                if (flyers.isEmpty()) {
+                                    item {
+                                        NothingToShowMessage(
+                                            title = "No upcoming flyers",
+                                            message = "If you want to see your organization’s events on Volume, email us at volumeappdev@gmail.com"
+                                        )
+                                    }
+                                } else {
+                                    items(flyers) {
+                                        Box(modifier = Modifier.padding(end = 16.dp)) {
+                                            SmallFlyer(
+                                                isExtraSmall = false,
+                                                it,
+                                                onOrganizationNameClick = onOrganizationNameClick
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+
+                        item {
+                            Spacer(modifier = Modifier.height(40.dp))
+                            VolumeHeaderText(
+                                text = "Past Flyers",
+                                underline = R.drawable.ic_underline_past_flyers
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                        }
+
+                        when (val pastFlyersState = uiState.pastFlyersState) {
+                            FlyersRetrievalState.Loading -> {
+                                items(5) {
+                                    ShimmeringFlyer()
+                                    Spacer(modifier = Modifier.height(16.dp))
+                                }
+                            }
+
+                            FlyersRetrievalState.Error -> {
+                                item {
+                                    ErrorState()
+                                }
+                            }
+
+                            is FlyersRetrievalState.Success -> {
+                                val flyers = pastFlyersState.flyers
+                                if (flyers.isEmpty()) {
+                                    item {
+                                        NothingToShowMessage(
+                                            title = "No past flyers",
+                                            message = "If you want to see your organization’s events on Volume, email us at volumeappdev@gmail.com"
+                                        )
+                                    }
+                                } else {
+                                    items(flyers) {
+                                        Box(modifier = Modifier.padding(end = 16.dp)) {
+                                            SmallFlyer(
+                                                isExtraSmall = false,
+                                                it,
+                                                onOrganizationNameClick = onOrganizationNameClick
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        item {
+                            NothingToShowMessage(
+                                title = "Are you an organization?",
+                                message = "If you want to see your organization’s events on Volume, email us at volumeappdev@gmail.com",
+                                showImage = true,
+                                modifier = Modifier.padding(bottom = 141.dp)
+                            )
                         }
                     }
                 }
             }
-        }
-
-
-        item {
-            Spacer(modifier = Modifier.height(40.dp))
-            VolumeHeaderText(text = "Past Flyers", underline = R.drawable.ic_underline_past_flyers)
-            Spacer(modifier = Modifier.height(8.dp))
-        }
-
-        when (val pastFlyersState = uiState.pastFlyersState) {
-            FlyersRetrievalState.Loading -> {
-                items(5) {
-                    ShimmeringFlyer()
-                    Spacer(modifier = Modifier.height(16.dp))
-                }
-            }
-
-            FlyersRetrievalState.Error -> {
-                item {
-                    ErrorState()
-                }
-            }
-
-            is FlyersRetrievalState.Success -> {
-                val flyers = pastFlyersState.flyers
-                if (flyers.isEmpty()) {
-                    item {
-                        NothingToShowMessage(
-                            title = "No past flyers",
-                            message = "If you want to see your organization’s events on Volume, email us at volumeappdev@gmail.com"
-                        )
-                    }
-                } else {
-                    items(flyers) {
-                        Box(modifier = Modifier.padding(end = 16.dp)) {
-                            SmallFlyer(isExtraSmall = false, it)
-                        }
-                    }
-                }
-            }
-        }
-        item {
-            NothingToShowMessage(
-                title = "Are you an organization?",
-                message = "If you want to see your organization’s events on Volume, email us at volumeappdev@gmail.com",
-                showImage = true,
-                modifier = Modifier.padding(bottom = 141.dp)
-            )
-        }
+        )
     }
+
+
 }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/IndividualOrganizationScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/IndividualOrganizationScreen.kt
@@ -1,0 +1,118 @@
+package com.cornellappdev.android.volume.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.cornellappdev.android.volume.data.models.Social
+import com.cornellappdev.android.volume.ui.components.general.CreateIndividualPartnerHeading
+import com.cornellappdev.android.volume.ui.components.general.ErrorState
+import com.cornellappdev.android.volume.ui.components.general.NothingToShowMessage
+import com.cornellappdev.android.volume.ui.components.general.ShimmeringFlyer
+import com.cornellappdev.android.volume.ui.components.general.SmallFlyer
+import com.cornellappdev.android.volume.ui.components.general.VolumeLoading
+import com.cornellappdev.android.volume.ui.states.ResponseState
+import com.cornellappdev.android.volume.ui.viewmodels.IndividualOrganizationViewModel
+import java.time.LocalDateTime
+
+@Composable
+fun IndividualOrganizationScreen(
+    onFollowClicked: () -> Unit,
+    individualOrganizationViewModel: IndividualOrganizationViewModel = hiltViewModel(),
+) {
+    val isFollowed = individualOrganizationViewModel.isFollowingFlow.collectAsState().value
+    val flyersState = individualOrganizationViewModel.orgFlyersFlow.collectAsState().value
+
+    val statsText = when (flyersState) {
+        ResponseState.Loading -> {
+            "..."
+        }
+
+        is ResponseState.Error -> {
+            "Error loading organization stats"
+        }
+
+        is ResponseState.Success -> {
+            val flyers = flyersState.data
+            val upcoming = flyers.count { it.endDateTime > LocalDateTime.now() }
+            "${flyers.size} events • $upcoming upcoming"
+        }
+    }
+
+    when (val organizationResult = individualOrganizationViewModel.orgFlow.collectAsState().value) {
+        ResponseState.Loading -> {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 20.dp), horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                VolumeLoading()
+            }
+        }
+
+        is ResponseState.Error -> {
+            ErrorState()
+        }
+
+        is ResponseState.Success -> {
+            val organization = organizationResult.data
+            LazyColumn {
+                item {
+                    CreateIndividualPartnerHeading(
+                        followButton = if (isFollowed is ResponseState.Success) isFollowed.data else false,
+                        followButtonClicked = { onFollowClicked() },
+                        backgroundImageUrl = organization.backgroundImageURL,
+                        profileImageURL = organization.profileImageURL,
+                        partnerName = organization.name,
+                        statsText = statsText,
+                        bio = organization.bio,
+                        socials = listOf(Social("web", organization.websiteURL)),
+                        websiteURL = organization.websiteURL,
+                    )
+                }
+                item {
+                    HeadingText(text = "Flyers")
+                }
+                when (flyersState) {
+                    ResponseState.Loading -> {
+                        items(5) {
+                            ShimmeringFlyer()
+                        }
+                    }
+
+                    is ResponseState.Error -> {
+                        item {
+                            ErrorState()
+                        }
+                    }
+
+                    is ResponseState.Success -> {
+                        val upcomingFlyers =
+                            flyersState.data.filter { it.endDateTime > LocalDateTime.now() }
+                        if (upcomingFlyers.isEmpty()) {
+                            item {
+                                NothingToShowMessage(
+                                    title = "There’s nothing here.",
+                                    message = "It seems like this organization hasn't published any flyers yet. ",
+                                    showImage = true,
+                                )
+                            }
+                        } else {
+                            items(flyersState.data) {
+                                SmallFlyer(isExtraSmall = false, flyer = it)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/IndividualOrganizationScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/IndividualOrganizationScreen.kt
@@ -24,7 +24,6 @@ import java.time.LocalDateTime
 
 @Composable
 fun IndividualOrganizationScreen(
-    onFollowClicked: () -> Unit,
     individualOrganizationViewModel: IndividualOrganizationViewModel = hiltViewModel(),
 ) {
     val isFollowed = individualOrganizationViewModel.isFollowingFlow.collectAsState().value
@@ -67,7 +66,7 @@ fun IndividualOrganizationScreen(
                 item {
                     CreateIndividualPartnerHeading(
                         followButton = if (isFollowed is ResponseState.Success) isFollowed.data else false,
-                        followButtonClicked = { onFollowClicked() },
+                        followButtonClicked = { TODO() },
                         backgroundImageUrl = organization.backgroundImageURL,
                         profileImageURL = organization.profileImageURL,
                         partnerName = organization.name,

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/IndividualPublicationScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/IndividualPublicationScreen.kt
@@ -35,8 +35,11 @@ fun IndividualPublicationScreen(
 
     var tabIndex by remember { mutableStateOf(0) };
 
-    // Publication heading
+    val statsText = "TODO get stats text"
+
     LazyVerticalGrid(columns = GridCells.Fixed(2)) {
+
+        // Publication heading item
         item(span = { GridItemSpan(2) }) {
             when (val publicationState = publicationUiState.publicationState) {
                 PublicationRetrievalState.Loading -> {
@@ -47,16 +50,24 @@ fun IndividualPublicationScreen(
                 }
 
                 is PublicationRetrievalState.Success -> {
-                    CreateIndividualPublicationHeading(
-                        publication = publicationState.publication,
-                        publicationUiState.isFollowed
-                    ) { isFollowing ->
-                        if (isFollowing) {
-                            individualPublicationViewModel.followPublication()
-                        } else {
-                            individualPublicationViewModel.unfollowPublication()
-                        }
-                    }
+                    val publication = publicationState.publication
+                    CreateIndividualPartnerHeading(
+                        followButton = publicationUiState.isFollowed,
+                        followButtonClicked = { isFollowing ->
+                            if (isFollowing) {
+                                individualPublicationViewModel.followPublication()
+                            } else {
+                                individualPublicationViewModel.unfollowPublication()
+                            }
+                        },
+                        backgroundImageUrl = publication.backgroundImageURL,
+                        profileImageURL = publication.profileImageURL,
+                        partnerName = publication.name,
+                        statsText = "${publication.numArticles} articles • ${publication.shoutouts.toInt()} shout-outs",
+                        bio = publication.bio,
+                        socials = publication.socials,
+                        websiteURL = publication.websiteURL,
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/MagazinesViewer.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/MagazinesViewer.kt
@@ -36,8 +36,6 @@ import com.cornellappdev.android.volume.ui.theme.VolumeOrange
 import com.cornellappdev.android.volume.ui.viewmodels.MagazinesViewModel
 import java.util.*
 
-private const val TAG = "MagazinesScreen"
-
 @RequiresApi(Build.VERSION_CODES.P)
 @Composable
 fun MagazinesViewer(

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/OrganizationHomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/OrganizationHomeScreen.kt
@@ -54,6 +54,7 @@ fun OrganizationHomeScreen(
     organizationsHomeViewModel: OrganizationsHomeViewModel = hiltViewModel(),
     onFlyerUploadClicked: () -> Unit,
     onFlyerEditClicked: (flyerId: String) -> Unit,
+    onOrganizationNameClick: (slug: String) -> Unit,
 ) {
     var selectedTabIndex by remember { mutableStateOf(0) }
     var alertDialogShowing by remember { mutableStateOf(false) }
@@ -224,7 +225,8 @@ fun OrganizationHomeScreen(
                                     onRemoveClick = {
                                         mostRecentlyClickedFlyerId = it.id
                                         alertDialogShowing = true
-                                    }
+                                    },
+                                    onOrganizationNameClick = onOrganizationNameClick
                                 )
                             }
                         }
@@ -269,7 +271,9 @@ fun OrganizationHomeScreen(
                                     onRemoveClick = {
                                         mostRecentlyClickedFlyerId = it.id
                                         alertDialogShowing = true
-                                    })
+                                    },
+                                    onOrganizationNameClick = onOrganizationNameClick
+                                )
                             }
                         }
 

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/OrganizationsMenu.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/OrganizationsMenu.kt
@@ -1,0 +1,110 @@
+package com.cornellappdev.android.volume.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.cornellappdev.android.volume.R
+import com.cornellappdev.android.volume.ui.components.general.CreatePartnerColumn
+import com.cornellappdev.android.volume.ui.components.general.CreatePartnerRow
+import com.cornellappdev.android.volume.ui.components.general.ErrorState
+import com.cornellappdev.android.volume.ui.components.general.VolumeHeaderText
+import com.cornellappdev.android.volume.ui.components.general.VolumeLoading
+import com.cornellappdev.android.volume.ui.states.ResponseState
+import com.cornellappdev.android.volume.ui.viewmodels.OrganizationsViewModel
+
+@Composable
+fun OrganizationsMenu(
+    organizationsViewModel: OrganizationsViewModel = hiltViewModel(),
+    onOrganizationSlugClick: (String) -> Unit,
+) {
+    val partitionedOrganizationsRes =
+        organizationsViewModel.partitionedOrgsFlow.collectAsState().value
+
+    when (partitionedOrganizationsRes) {
+        is ResponseState.Error -> {
+            ErrorState()
+        }
+
+        ResponseState.Loading -> {
+            VolumeLoading()
+        }
+
+        is ResponseState.Success -> {
+            val (followedOrganizations, unfollowedOrganizations) = partitionedOrganizationsRes.data
+            Row(modifier = Modifier.padding(top = 25.dp)) {
+                LazyColumn(modifier = Modifier.padding(horizontal = 12.dp)) {
+                    item {
+                        VolumeHeaderText(
+                            text = "Following",
+                            underline = R.drawable.ic_underline_following,
+                        )
+                        Spacer(modifier = Modifier.height(10.dp))
+                    }
+
+                    item {
+                        LazyRow(
+                            horizontalArrangement = Arrangement.spacedBy(24.dp),
+                        ) {
+                            items(followedOrganizations) {
+                                CreatePartnerColumn(
+                                    profileImageURL = it.profileImageURL,
+                                    slug = it.slug,
+                                    title = it.name,
+                                    onPartnerClick = onOrganizationSlugClick
+                                )
+                            }
+                        }
+                    }
+                    item {
+                        VolumeHeaderText(
+                            text = "More Organizations",
+                            underline = R.drawable.ic_underline_more_publications,
+                            modifier = Modifier.padding(top = 30.dp)
+                        )
+
+                        Spacer(modifier = Modifier.height(22.dp))
+                    }
+                    items(unfollowedOrganizations) {
+                        CreatePartnerRow(
+                            profileImageURL = it.profileImageURL,
+                            name = it.name,
+                            slug = it.slug,
+                            bio = it.bio,
+                            onPartnerClick = onOrganizationSlugClick,
+                            isFollowed = it.slug in followedOrganizations.map { org -> org.slug },
+                            followButtonClicked = { partnerSlug, isFollowed ->
+                                if (isFollowed) {
+                                    organizationsViewModel.unfollowOrganization(partnerSlug)
+                                } else {
+                                    organizationsViewModel.followOrganization(partnerSlug)
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        item {
+            VolumeHeaderText(
+                text = "Following",
+                underline = R.drawable.ic_underline_following,
+                modifier = Modifier.padding(start = 12.dp, top = 25.dp)
+            )
+
+            Spacer(modifier = Modifier.height(10.dp))
+        }
+    }
+}

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/PublicationsMenu.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/PublicationsMenu.kt
@@ -15,9 +15,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.cornellappdev.android.volume.R
-import com.cornellappdev.android.volume.data.models.Publication
-import com.cornellappdev.android.volume.ui.components.general.CreatePublicationColumn
-import com.cornellappdev.android.volume.ui.components.general.CreatePublicationRow
+import com.cornellappdev.android.volume.ui.components.general.CreatePartnerColumn
+import com.cornellappdev.android.volume.ui.components.general.CreatePartnerRow
 import com.cornellappdev.android.volume.ui.components.general.ErrorState
 import com.cornellappdev.android.volume.ui.components.general.VolumeHeaderText
 import com.cornellappdev.android.volume.ui.components.general.VolumeLoading
@@ -29,7 +28,7 @@ private const val TAG = "PublicationsMenu"
 @Composable
 fun PublicationsMenu(
     publicationsViewModel: PublicationsViewModel = hiltViewModel(),
-    onPublicationClick: (Publication) -> Unit,
+    onPublicationClick: (String) -> Unit,
 ) {
     val publicationsUiState = publicationsViewModel.publicationsUiState
 
@@ -65,8 +64,12 @@ fun PublicationsMenu(
                     ) {
 
                         items(followingPublicationsState.publications) { publication ->
-                            CreatePublicationColumn(publication) {
-                                onPublicationClick(publication)
+                            CreatePartnerColumn(
+                                profileImageURL = publication.profileImageURL,
+                                slug = publication.slug,
+                                title = publication.name
+                            ) {
+                                onPublicationClick(it)
                             }
                         }
                     }
@@ -106,17 +109,22 @@ fun PublicationsMenu(
                             top = if (index != 0) 24.dp else 0.dp
                         )
                     ) {
-                        CreatePublicationRow(
-                            publication = publication,
-                            onPublicationClick
-                        ) { publicationFromCallback, isFollowing ->
+                        CreatePartnerRow(
+                            bio = publication.bio,
+                            name = publication.name,
+                            onPartnerClick = onPublicationClick,
+                            profileImageURL = publication.profileImageURL,
+                            slug = publication.slug,
+                            mostRecentArticleTitle = publication.mostRecentArticle?.title,
+                            isFollowed = false,
+                        ) { slug, isFollowing ->
                             if (isFollowing) {
-                                publicationsViewModel.followPublication(
-                                    publicationFromCallback.slug
+                                publicationsViewModel.unfollowPublication(
+                                    slug
                                 )
                             } else {
-                                publicationsViewModel.unfollowPublication(
-                                    publicationFromCallback.slug
+                                publicationsViewModel.followPublication(
+                                    slug
                                 )
                             }
                         }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/ReadsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/ReadsScreen.kt
@@ -22,7 +22,6 @@ import com.cornellappdev.android.volume.analytics.NavigationSource
 import com.cornellappdev.android.volume.data.models.Article
 import com.cornellappdev.android.volume.data.models.Magazine
 import com.cornellappdev.android.volume.data.models.Organization
-import com.cornellappdev.android.volume.data.models.Publication
 import com.cornellappdev.android.volume.ui.components.general.SearchBar
 import com.cornellappdev.android.volume.ui.components.general.VolumePeriod
 import com.cornellappdev.android.volume.ui.theme.VolumeOffWhite
@@ -39,7 +38,7 @@ fun ReadsScreen(
     onArticleClick: (Article, NavigationSource) -> Unit,
     showBottomBar: MutableState<Boolean>,
     onMagazineClick: (Magazine) -> Unit,
-    onPublicationClick: (Publication) -> Unit,
+    onPublicationClick: (String) -> Unit,
     onSearchClick: (Int) -> Unit,
     onOrganizationClick: (Organization) -> Unit,
 ) {

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/ReadsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/ReadsScreen.kt
@@ -21,6 +21,7 @@ import com.cornellappdev.android.volume.R
 import com.cornellappdev.android.volume.analytics.NavigationSource
 import com.cornellappdev.android.volume.data.models.Article
 import com.cornellappdev.android.volume.data.models.Magazine
+import com.cornellappdev.android.volume.data.models.Organization
 import com.cornellappdev.android.volume.data.models.Publication
 import com.cornellappdev.android.volume.ui.components.general.SearchBar
 import com.cornellappdev.android.volume.ui.components.general.VolumePeriod
@@ -40,6 +41,7 @@ fun ReadsScreen(
     onMagazineClick: (Magazine) -> Unit,
     onPublicationClick: (Publication) -> Unit,
     onSearchClick: (Int) -> Unit,
+    onOrganizationClick: (Organization) -> Unit,
 ) {
     val scaffoldState = rememberScaffoldState()
     val coroutineScope = rememberCoroutineScope()

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/SearchScreen.kt
@@ -55,6 +55,7 @@ fun SearchScreen(
     searchViewModel: SearchViewModel = hiltViewModel(),
     onMagazineClick: (Magazine) -> Unit,
     onArticleClick: (Article, NavigationSource) -> Unit,
+    onOrganizationNameClick: (slug: String) -> Unit,
     defaultTab: Int = 0,
 ) {
     var search by remember { mutableStateOf("") }
@@ -251,7 +252,11 @@ fun SearchScreen(
                                     horizontalAlignment = Alignment.CenterHorizontally
                                 ) {
                                     Box(modifier = Modifier.padding(horizontal = 16.dp)) {
-                                        SmallFlyer(isExtraSmall = false, it)
+                                        SmallFlyer(
+                                            isExtraSmall = false,
+                                            it,
+                                            onOrganizationNameClick = onOrganizationNameClick
+                                        )
                                     }
                                 }
                                 Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/screens/TrendingScreen.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/screens/TrendingScreen.kt
@@ -48,6 +48,7 @@ fun TrendingScreen(
     trendingViewModel: TrendingViewModel = hiltViewModel(),
     onArticleClick: (Article, NavigationSource) -> Unit,
     onMagazineClick: (Magazine) -> Unit,
+    onOrganizationNameClick: (slug: String) -> Unit,
 ) {
     val config = LocalConfiguration.current
     val screenWidthDp = config.screenWidthDp.dp
@@ -159,7 +160,11 @@ fun TrendingScreen(
                     Column {
                         Row {
                             Spacer(modifier = Modifier.width(16.dp))
-                            BigFlyer(imgSize = screenWidthDp - 32.dp, flyer = flyers[index])
+                            BigFlyer(
+                                imgSize = screenWidthDp - 32.dp,
+                                flyer = flyers[index],
+                                onOrganizationNameClick = onOrganizationNameClick
+                            )
                         }
                         Spacer(modifier = Modifier.height(40.dp))
                     }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/states/ApiResponseState.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/states/ApiResponseState.kt
@@ -2,6 +2,7 @@ package com.cornellappdev.android.volume.ui.states
 
 /**
  * A generic response state class for the loading, error, and success states during network requests.
+ * Delete all other response state classes, and replace them with this one
  */
 sealed class ResponseState<out T> {
     object Loading : ResponseState<Nothing>()

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/IndividualOrganizationViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/IndividualOrganizationViewModel.kt
@@ -10,11 +10,13 @@ import com.cornellappdev.android.volume.data.repositories.OrganizationRepository
 import com.cornellappdev.android.volume.data.repositories.UserPreferencesRepository
 import com.cornellappdev.android.volume.data.repositories.UserRepository
 import com.cornellappdev.android.volume.ui.states.ResponseState
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@HiltViewModel
 class IndividualOrganizationViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val userPreferencesRepository: UserPreferencesRepository,
@@ -71,6 +73,27 @@ class IndividualOrganizationViewModel @Inject constructor(
         } catch (_: Exception) {
             _isFollowingFlow.value = ResponseState.Error()
         }
+    }
 
+    fun followOrganization() = viewModelScope.launch {
+        val uuid = userPreferencesRepository.fetchUuid()
+        try {
+            val newUser = userRepository.followOrganization(organizationSlug, uuid)
+            _isFollowingFlow.value =
+                ResponseState.Success(organizationSlug in newUser.followedOrganizationSlugs)
+        } catch (_: Exception) {
+            _isFollowingFlow.value = ResponseState.Error()
+        }
+    }
+
+    fun unfollowOrganization() = viewModelScope.launch {
+        val uuid = userPreferencesRepository.fetchUuid()
+        try {
+            val newUser = userRepository.unfollowOrganization(organizationSlug, uuid)
+            _isFollowingFlow.value =
+                ResponseState.Success(organizationSlug in newUser.followedOrganizationSlugs)
+        } catch (_: Exception) {
+            _isFollowingFlow.value = ResponseState.Error()
+        }
     }
 }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/IndividualOrganizationViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/IndividualOrganizationViewModel.kt
@@ -1,0 +1,76 @@
+package com.cornellappdev.android.volume.ui.viewmodels
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.cornellappdev.android.volume.data.models.Flyer
+import com.cornellappdev.android.volume.data.models.Organization
+import com.cornellappdev.android.volume.data.repositories.FlyerRepository
+import com.cornellappdev.android.volume.data.repositories.OrganizationRepository
+import com.cornellappdev.android.volume.data.repositories.UserPreferencesRepository
+import com.cornellappdev.android.volume.data.repositories.UserRepository
+import com.cornellappdev.android.volume.ui.states.ResponseState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class IndividualOrganizationViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val userPreferencesRepository: UserPreferencesRepository,
+    private val organizationRepository: OrganizationRepository,
+    private val userRepository: UserRepository,
+    private val flyersRepository: FlyerRepository,
+) : ViewModel() {
+    private val _orgFlyersFlow: MutableStateFlow<ResponseState<List<Flyer>>> =
+        MutableStateFlow(ResponseState.Loading)
+    val orgFlyersFlow = _orgFlyersFlow.asStateFlow()
+
+    private val _orgFlow: MutableStateFlow<ResponseState<Organization>> =
+        MutableStateFlow(ResponseState.Loading)
+    val orgFlow = _orgFlow.asStateFlow()
+
+    private val _isFollowingFlow: MutableStateFlow<ResponseState<Boolean>> =
+        MutableStateFlow(ResponseState.Loading)
+    val isFollowingFlow = _isFollowingFlow.asStateFlow()
+
+    private val organizationSlug: String = checkNotNull(savedStateHandle["organizationSlug"])
+
+    init {
+        loadOrganization()
+        checkFollowing()
+        loadFlyers()
+    }
+
+    private fun loadOrganization() = viewModelScope.launch {
+        try {
+            _orgFlow.value = ResponseState.Success(
+                organizationRepository.getOrganizationBySlug(organizationSlug)!!
+            )
+        } catch (_: Exception) {
+            _orgFlow.value = ResponseState.Error()
+        }
+
+    }
+
+    private fun loadFlyers() = viewModelScope.launch {
+        try {
+            _orgFlyersFlow.value = ResponseState.Success(
+                flyersRepository.fetchFlyersByOrganizationSlug(organizationSlug)
+            )
+        } catch (_: Exception) {
+            _orgFlyersFlow.value = ResponseState.Error()
+        }
+    }
+
+    private fun checkFollowing() = viewModelScope.launch {
+        try {
+            val user = userRepository.getUser(userPreferencesRepository.fetchUuid())
+            _isFollowingFlow.value =
+                ResponseState.Success(organizationSlug in user.followedOrganizationSlugs)
+        } catch (_: Exception) {
+            _isFollowingFlow.value = ResponseState.Error()
+        }
+
+    }
+}

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/IndividualPublicationViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/IndividualPublicationViewModel.kt
@@ -6,7 +6,11 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.cornellappdev.android.volume.data.repositories.*
+import com.cornellappdev.android.volume.data.repositories.ArticleRepository
+import com.cornellappdev.android.volume.data.repositories.MagazineRepository
+import com.cornellappdev.android.volume.data.repositories.PublicationRepository
+import com.cornellappdev.android.volume.data.repositories.UserPreferencesRepository
+import com.cornellappdev.android.volume.data.repositories.UserRepository
 import com.cornellappdev.android.volume.ui.states.ArticlesRetrievalState
 import com.cornellappdev.android.volume.ui.states.MagazinesRetrievalState
 import com.cornellappdev.android.volume.ui.states.PublicationRetrievalState
@@ -14,7 +18,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-private const val TAG = "IndividualPublicationViewModel"
 @HiltViewModel
 class IndividualPublicationViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
@@ -22,15 +25,16 @@ class IndividualPublicationViewModel @Inject constructor(
     private val articleRepository: ArticleRepository,
     private val magazineRepository: MagazineRepository,
     private val userRepository: UserRepository,
-    private val publicationRepository: PublicationRepository
+    private val publicationRepository: PublicationRepository,
 ) : ViewModel() {
 
     private val publicationSlug: String = checkNotNull(savedStateHandle["publicationSlug"])
+
     data class PublicationUiState(
         val publicationState: PublicationRetrievalState = PublicationRetrievalState.Loading,
         val articlesByPublicationState: ArticlesRetrievalState = ArticlesRetrievalState.Loading,
         val magazinesByPublicationState: MagazinesRetrievalState = MagazinesRetrievalState.Loading,
-        val isFollowed: Boolean = false
+        val isFollowed: Boolean = false,
     )
 
     var publicationUiState by mutableStateOf(PublicationUiState())
@@ -79,13 +83,13 @@ class IndividualPublicationViewModel @Inject constructor(
 
     private fun queryArticleByPublication() = viewModelScope.launch {
         try {
-             publicationUiState = publicationUiState.copy(
+            publicationUiState = publicationUiState.copy(
                 articlesByPublicationState = ArticlesRetrievalState.Success(
                     articleRepository.fetchArticlesByPublicationSlug(publicationSlug)
                 )
             )
         } catch (e: Exception) {
-             publicationUiState = publicationUiState.copy(
+            publicationUiState = publicationUiState.copy(
                 articlesByPublicationState = ArticlesRetrievalState.Error
             )
         }

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/OrganizationLoginViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/OrganizationLoginViewModel.kt
@@ -60,7 +60,10 @@ class OrganizationLoginViewModel @Inject constructor
                             categorySlug = it.categorySlug,
                             websiteURL = it.websiteURL,
                             id = it.id,
-                            slug = it.slug
+                            slug = it.slug,
+                            backgroundImageURL = it.backgroundImageURL,
+                            bio = it.bio,
+                            profileImageURL = it.profileImageURL,
                         )
                     )
                 )

--- a/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/OrganizationsViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/ui/viewmodels/OrganizationsViewModel.kt
@@ -1,0 +1,95 @@
+package com.cornellappdev.android.volume.ui.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.cornellappdev.android.volume.data.NetworkApi
+import com.cornellappdev.android.volume.data.models.Organization
+import com.cornellappdev.android.volume.data.repositories.OrganizationRepository
+import com.cornellappdev.android.volume.data.repositories.UserPreferencesRepository
+import com.cornellappdev.android.volume.data.repositories.UserRepository
+import com.cornellappdev.android.volume.ui.states.ResponseState
+import com.cornellappdev.android.volume.util.transformWithResponseState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class OrganizationsViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+    private val userPreferencesRepository: UserPreferencesRepository,
+    private val organizationsRepository: OrganizationRepository,
+    private val networkApi: NetworkApi,
+) : ViewModel() {
+    private val allOrganizationsFlow: MutableStateFlow<ResponseState<List<Organization>>> =
+        MutableStateFlow(ResponseState.Loading)
+
+
+    private val _followedOrganizationSlugsFlow: MutableStateFlow<ResponseState<List<String>>> =
+        MutableStateFlow(ResponseState.Loading)
+
+    /**
+     * This flow represents a partition (p1, p2), where p1 is the organizations that the user follows,
+     * and p2 is the organizations the user doesn't follow
+     */
+    val partitionedOrgsFlow: StateFlow<ResponseState<Pair<List<Organization>, List<Organization>>>> =
+        allOrganizationsFlow.combine(_followedOrganizationSlugsFlow) { allOrganizations, followedSlugs ->
+            transformWithResponseState(allOrganizations, followedSlugs) { orgs, slugs ->
+                orgs.partition { it.slug in slugs }
+            }
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, ResponseState.Loading)
+
+
+    init {
+        queryAllOrganizations()
+        queryFollowedOrganizationSlugs()
+    }
+
+    private fun queryFollowedOrganizationSlugs() = viewModelScope.launch {
+        try {
+            _followedOrganizationSlugsFlow.value = ResponseState.Loading
+            val uuid = userPreferencesRepository.fetchUuid()
+            val currentUser = userRepository.getUser(uuid)
+            _followedOrganizationSlugsFlow.value =
+                ResponseState.Success(currentUser.followedOrganizationSlugs)
+        } catch (_: Exception) {
+            _followedOrganizationSlugsFlow.value = ResponseState.Error()
+        }
+    }
+
+    private fun queryAllOrganizations() = viewModelScope.launch {
+        try {
+            allOrganizationsFlow.value = ResponseState.Loading
+            allOrganizationsFlow.value =
+                ResponseState.Success(organizationsRepository.getAllOrganizations())
+        } catch (_: Exception) {
+            allOrganizationsFlow.value = ResponseState.Error()
+        }
+    }
+
+    fun reload() {
+        queryAllOrganizations()
+        queryFollowedOrganizationSlugs()
+    }
+
+    fun followOrganization(organizationSlug: String) = viewModelScope.launch {
+        try {
+            val uuid = userPreferencesRepository.fetchUuid()
+            userRepository.followOrganization(organizationSlug, uuid)
+        } catch (_: Exception) {
+        }
+    }
+
+    fun unfollowOrganization(organizationSlug: String) = viewModelScope.launch {
+        try {
+            val uuid = userPreferencesRepository.fetchUuid()
+            userRepository.unfollowOrganization(organizationSlug, uuid)
+        } catch (_: Exception) {
+        }
+    }
+
+}

--- a/app/src/main/java/com/cornellappdev/android/volume/util/GeneralUtil.kt
+++ b/app/src/main/java/com/cornellappdev/android/volume/util/GeneralUtil.kt
@@ -3,6 +3,7 @@ package com.cornellappdev.android.volume.util
 import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
+import com.cornellappdev.android.volume.ui.states.ResponseState
 
 inline fun <T : Any, R : Any> letIfAllNotNull(vararg arguments: T?, block: (List<T>) -> R): R? {
     return if (arguments.all { it != null }) {
@@ -23,4 +24,35 @@ fun deriveFileName(uri: Uri, context: Context): String? {
     }
     cursor?.close()
     return null
+}
+
+/**
+ * Generic function to handle applying a transformation function to two response states.
+ * If either response state has an error, it returns an error response state.
+ * If either response state is loading, it returns a loading response state.
+ * If both response states are successful, it applies `transform` to a and b and returns a successful
+ * response state with transform applied.
+ *
+ * @param a the first response state
+ * @param b the second response state
+ * @param transform the transformation function that is applied to (a, b) if both a and b are successful.
+ */
+fun <T1, T2, R> transformWithResponseState(
+    a: ResponseState<T1>,
+    b: ResponseState<T2>,
+    transform: (a: T1, b: T2) -> R,
+): ResponseState<R> {
+    if (a is ResponseState.Error || b is ResponseState.Error) {
+        return ResponseState.Error()
+    }
+    if (a is ResponseState.Loading || b is ResponseState.Loading) {
+        return ResponseState.Loading
+    }
+    if (a is ResponseState.Success && b is ResponseState.Success) {
+        return ResponseState.Success(transform(a.data, b.data))
+    }
+
+    // The code should never reach here, we've covered all cases. I'd rather not throw an exception
+    // though because that could crash the app.
+    return ResponseState.Error()
 }

--- a/app/src/main/res/drawable/ic_underline_flyers.xml
+++ b/app/src/main/res/drawable/ic_underline_flyers.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="58dp"
+    android:height="6dp"
+    android:viewportWidth="58"
+    android:viewportHeight="6">
+  <path
+      android:pathData="M0.756,5.127C16.849,0.385 34.801,1.145 56.805,0.95"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#D07000"
+      android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
## Overview
Implemented page to view details about individual organizations, also implemented sidebar menu for Flyers page for users to discover new organizations to follow and view their followed organizations.


## Changes Made

- Added sidebar to Flyers screen for viewing followed organizations
- Added organizations home page
- Refactored individual publications page components to be more generalized
- Implemented flows to manage organization state and followed organizations
- Allow users to follow organizations and update networking accordingly.


## Test Coverage

Tested viewing, following, and unfollowing a variety of organizations, and everything worked as expected.

## Screenshots & Videos
[demo.webm](https://github.com/cuappdev/volume-compose-android/assets/58796478/7dd49b18-2bce-4b6e-8839-c5bf9f27bd7e)
